### PR TITLE
[ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/e-navigator/Gemfile
+++ b/ruby-on-rails/e-navigator/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 8.1.3'
 # Use mysql2 as the database for Active Record
 gem 'mysql2', '~> 0.5.7'
 # Use Puma as the app server
-gem 'puma', '~> 7.2.0'
+gem 'puma', '~> 8.0.0'
 # Use Propshaft as the asset pipeline
 gem 'propshaft', '~> 1.3.1'
 # Use importmap for JavaScript
@@ -46,7 +46,7 @@ group :test do
   gem 'factory_bot_rails', '~> 6.5.1'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 3.40.0'
-  gem 'selenium-webdriver', '~> 4.41.0'
+  gem 'selenium-webdriver', '~> 4.43.0'
   gem 'matrix', '~> 0.4.2'
   gem 'rails-controller-testing', '~> 1.0.5'
 end

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -244,7 +244,7 @@ GEM
     rexml (3.4.4)
     rubyzip (3.2.2)
     securerandom (0.4.1)
-    selenium-webdriver (4.41.0)
+    selenium-webdriver (4.43.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -295,10 +295,10 @@ DEPENDENCIES
   matrix (~> 0.4.2)
   mysql2 (~> 0.5.7)
   propshaft (~> 1.3.1)
-  puma (~> 7.2.0)
+  puma (~> 8.0.0)
   rails (~> 8.1.3)
   rails-controller-testing (~> 1.0.5)
-  selenium-webdriver (~> 4.41.0)
+  selenium-webdriver (~> 4.43.0)
   turbo-rails (~> 2.0.16)
   tzinfo-data
   web-console (~> 4.3.0)
@@ -369,7 +369,7 @@ CHECKSUMS
   propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
@@ -388,7 +388,7 @@ CHECKSUMS
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  selenium-webdriver (4.41.0) sha256=cdc1173cd55cf186022cea83156cc2d0bec06d337e039b02ad25d94e41bedd22
+  selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile
@@ -6,9 +6,9 @@ ruby file: '.ruby-version'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.1.3'
 # Use Puma as the app server
-gem 'puma', '~> 7.2.0'
+gem 'puma', '~> 8.0.0'
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
-gem 'propshaft', '~> 1.1.0'
+gem 'propshaft', '~> 1.3.1'
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem 'jsbundling-rails', '~> 1.3.1'
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
@@ -91,7 +91,7 @@ group :test do
   gem 'factory_bot_rails', '~> 6.5.1'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 3.40.0'
-  gem 'selenium-webdriver', '~> 4.41.0'
+  gem 'selenium-webdriver', '~> 4.43.0'
   gem 'matrix', '~> 0.4.2'
 end
 

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -229,16 +229,15 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    propshaft (1.1.0)
+    propshaft (1.3.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-      railties (>= 7.0.0)
     psych (5.3.1)
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -304,7 +303,7 @@ GEM
       logger
     rubyzip (3.2.2)
     securerandom (0.4.1)
-    selenium-webdriver (4.41.0)
+    selenium-webdriver (4.43.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -365,14 +364,14 @@ DEPENDENCIES
   omniauth-github (~> 2.0.1)
   omniauth-rails_csrf_protection (~> 2.0.1)
   ostruct (~> 0.6.3)
-  propshaft (~> 1.1.0)
+  propshaft (~> 1.3.1)
   psych (~> 5.3.1)
-  puma (~> 7.2.0)
+  puma (~> 8.0.0)
   rails (~> 8.1.3)
   rails-i18n (~> 8.1.0)
   ransack (~> 4.4.1)
   rexml (~> 3.4.4)
-  selenium-webdriver (~> 4.41.0)
+  selenium-webdriver (~> 4.43.0)
   turbo-rails (~> 2.0.16)
   tzinfo-data
   web-console (~> 4.3.0)
@@ -458,10 +457,10 @@ CHECKSUMS
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  propshaft (1.1.0) sha256=d389361faf66aeb17e8d204828962c1e506edd14a1a17adb3fa475435c070f6b
+  propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
@@ -482,7 +481,7 @@ CHECKSUMS
   ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  selenium-webdriver (4.41.0) sha256=cdc1173cd55cf186022cea83156cc2d0bec06d337e039b02ad25d94e41bedd22
+  selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
   snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73

--- a/ruby-on-rails/restful-api/Gemfile
+++ b/ruby-on-rails/restful-api/Gemfile
@@ -6,7 +6,7 @@ ruby file: '.ruby-version'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.1.3'
 # Use Puma as the app server
-gem 'puma', '~> 7.2.0'
+gem 'puma', '~> 8.0.0'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/ruby-on-rails/restful-api/Gemfile.lock
+++ b/ruby-on-rails/restful-api/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    puma (7.2.0)
+    puma (8.0.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -281,7 +281,7 @@ DEPENDENCIES
   nokogiri (~> 1.19.2)
   observer (~> 0.1.2)
   ostruct (~> 0.6.3)
-  puma (~> 7.2.0)
+  puma (~> 8.0.0)
   rails (~> 8.1.3)
   rspec-rails (~> 8.0.4)
   shoulda-matchers (~> 7.0.1)
@@ -357,7 +357,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8


### PR DESCRIPTION
## 1. Puma: 7.2.0 → 8.0.0

| | **7.2.0** | **8.0.0** |
|---|---|---|
| **Release Date** | 2026-01-20 | 2026-03-27 |
| **Codename** | On The Corner | Into the Arena |
| **Type** | Minor release | Major release |

### 1-1. Breaking Changes (8.0.0)

- Default production bind address changed from `0.0.0.0` (IPv4) to `::` (IPv6) when a non-loopback IPv6 interface is available; falls back to `0.0.0.0` otherwise ([#3847](https://github.com/puma/puma/pull/3847))

### 1-2. New Features

| Version | Feature |
|---|---|
| 7.2.0 | Add workers `:auto` ([#3827](https://github.com/puma/puma/pull/3827)) |
| 7.2.0 | Restrict control server commands to stats only ([#3787](https://github.com/puma/puma/pull/3787)) |
| 8.0.0 | `env["puma.mark_as_io_bound"]` API and `max_io_threads` config for mixed workloads ([#3816](https://github.com/puma/puma/pull/3816), [#3894](https://github.com/puma/puma/pull/3894)) |
| 8.0.0 | `single` and `cluster` DSL hooks for mode-specific configuration ([#3621](https://github.com/puma/puma/pull/3621)) |
| 8.0.0 | `on_force` option for `shutdown_debug` ([#3671](https://github.com/puma/puma/pull/3671)) |
| 8.0.0 | Runtime thread pool tuning via `update_thread_pool_min_max` and `ServerPluginControl` ([#3658](https://github.com/puma/puma/pull/3658)) |
| 8.0.0 | SIGPWR for thread backtrace dumps on Linux/JRuby ([#3829](https://github.com/puma/puma/pull/3829)) |

### 1-3. Bugfixes

| Version | Fix |
|---|---|
| 7.2.0 | Don't break if `WEB_CONCURRENCY` is blank ([#3837](https://github.com/puma/puma/pull/3837)) |
| 7.2.0 | Don't share server between worker 0 and descendants on refork ([#3602](https://github.com/puma/puma/pull/3602)) |
| 7.2.0 | Fix phase check race condition in `Puma::Cluster#check_workers` ([#3690](https://github.com/puma/puma/pull/3690)) |
| 7.2.0 | Fix advertising of CLI config before config files load ([#3823](https://github.com/puma/puma/pull/3823)) |
| 8.0.0 | Fix phased restart for `fork_worker` with stale worker 0 ([#3853](https://github.com/puma/puma/pull/3853)) |

### 1-4. Performance

| Version | Improvement |
|---|---|
| 7.2.0 | 17% faster HTTP parsing via pre-interned env keys ([#3825](https://github.com/puma/puma/pull/3825)) |
| 7.2.0 | GC-compactible C extension (`dsize`/`dcompact` for `HttpParser`) ([#3828](https://github.com/puma/puma/pull/3828)) |
| 8.0.0 | JRuby HTTP parser: pre-allocated header keys, perfect hash lookup, reduced memory copies ([#3838](https://github.com/puma/puma/pull/3838)) |
| 8.0.0 | Cache downcased header key in `str_headers`, ~50% fewer allocations per response ([#3874](https://github.com/puma/puma/pull/3874)) |

### 1-5. Upgrade Notes

Review the [8.0 Upgrade Guide](https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md) before upgrading. The IPv6 default bind change is the primary breaking change to watch for.

## 2. Propshaft: 1.1.0 → 1.3.1

| | **1.1.0** | **1.3.1** |
|---|---|---|
| **Release Date** | 2024-10-01 | 2025-09-24 |

### 2-1. Intermediate Versions: 1.2.0, 1.2.1, 1.3.0, 1.3.1

### 2-2. v1.2.0 (2025-07-16) — Major Changes

- **Manifest format updated** to support Subresource Integrity (SRI). The manifest now uses an object per asset instead of a simple string:
  ```json
  // Old format
  { "logical_path.js": "logical_path-digest123.js" }
  // New format
  { "logical_path.js": { "digested_path": "logical_path-digest123.js", "integrity": "sha384-hash..." } }
  ```
  Propshaft can still read the old format. If tools manually parse `.manifest.json`, they need updating.
- Read asset content in binary mode (fixes CRLF conversion on Windows) ([#222](https://github.com/rails/propshaft/pull/222))
- Add quotes to ETags ([#220](https://github.com/rails/propshaft/pull/220))
- Fix CSS Asset Compiler to work with files starting with `data` and `http` ([#224](https://github.com/rails/propshaft/pull/224))
- Server should also sweep cache ([#232](https://github.com/rails/propshaft/pull/232))
- Remove railties runtime dependency ([#239](https://github.com/rails/propshaft/pull/239))
- Add Subresource Integrity value to manifest ([#238](https://github.com/rails/propshaft/pull/238))

### 2-3. v1.2.1 (2025-07-19)

- Only sweep the cache if cache sweeping is enabled ([#245](https://github.com/rails/propshaft/pull/245))
- Change `stylesheet_link_tag` and `javascript_include_tag` to extract options from sources
- Add a method to delete manifest entries

### 2-4. v1.3.0 (2025-09-24)

- Turn `Propshaft::Server` into a proper middleware ([#249](https://github.com/rails/propshaft/pull/249))

### 2-5. v1.3.1 (2025-09-24)

- Same-day patch release for v1.3.0 (minor fix, no release notes published)

### 2-6. Key Takeaways

1. **Manifest format change** in 1.2.0 — any code manually parsing `.manifest.json` must be updated.
2. **SRI support** — integrity hashes are now available in the manifest.
3. **railties is no longer a runtime dependency** — Propshaft is now more standalone.
4. `Propshaft::Server` is now a proper Rack middleware (1.3.0).

## 3. selenium-webdriver: 4.41.0 → 4.43.0

| | **4.41.0** | **4.43.0** |
|---|---|---|
| **Release Date** | 2026-02-19 | 2026-04-09 |

### 3-1. v4.41.0 (2026-02-19)

- Support CDP versions: v143, v144, v145
- Remove stored atoms — these get generated by build ([#16971](https://github.com/SeleniumHQ/selenium/pull/16971))
- Output driver logs when `SE_DEBUG` is enabled ([#16901](https://github.com/SeleniumHQ/selenium/pull/16901))
- Update lint configuration and fix RuboCop offenses ([#17008](https://github.com/SeleniumHQ/selenium/pull/17008))
- Add missing unit tests ([#17025](https://github.com/SeleniumHQ/selenium/pull/17025))
- Add session event API for server-side event bus integration (Grid) ([#17015](https://github.com/SeleniumHQ/selenium/pull/17015))
- Update dependencies ([#17111](https://github.com/SeleniumHQ/selenium/pull/17111))

### 3-2. v4.42.0 (2026-04-08)

- Support CDP versions: v144, v145, v146

### 3-3. v4.43.0 (2026-04-09)

- Support CDP versions: v145, v146, v147

### 3-4. Key Takeaways

1. **CDP version updates** are the primary changes — rotating Chrome DevTools Protocol support through v143–v147.
2. **Debug logging** — driver logs are now output when `SE_DEBUG` is enabled.
3. **Grid session events** — new API for server-side event bus integration.
4. These are minor, incremental updates with no breaking changes.