### PR TITLE
[e-navigator] Introduce Steep Typechecking

### DIFF
--- a/.github/workflows/ruby-on-rails--e-navigator.yml
+++ b/.github/workflows/ruby-on-rails--e-navigator.yml
@@ -5,14 +5,14 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: e-Navigator
+name: Ruby on Rails - e-Navigator
 
 on:
   push:
     branches:
       - master
     paths:
-      - '.github/workflows/minitest--e-navigator.yml'
+      - '.github/workflows/ruby-on-rails--e-navigator.yml'
       - '.ruby-version'
       - 'ruby-on-rails/e-navigator/.ruby-version'
       - 'ruby-on-rails/e-navigator/Gemfile'
@@ -27,7 +27,7 @@ on:
       - 'ruby-on-rails/e-navigator/**/*.html.erb'
   pull_request:
     paths:
-      - '.github/workflows/minitest--e-navigator.yml'
+      - '.github/workflows/ruby-on-rails--e-navigator.yml'
       - '.ruby-version'
       - 'ruby-on-rails/e-navigator/.ruby-version'
       - 'ruby-on-rails/e-navigator/Gemfile'
@@ -89,3 +89,9 @@ jobs:
       - name: Run Brakeman
         working-directory: ./ruby-on-rails/e-navigator
         run: bundle exec brakeman --no-pager
+      - name: Generate RBS
+        working-directory: ./ruby-on-rails/e-navigator
+        run: bundle exec rbs-inline --output sig
+      - name: Run Steep
+        working-directory: ./ruby-on-rails/e-navigator
+        run: bundle exec steep check

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Actions Status: JavaScript](https://github.com/hayat01sh1da/tutorials/workflows/JavaScript/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22JavaScript%22)
 [![Actions Status: Python](https://github.com/hayat01sh1da/tutorials/workflows/Python/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22Python%22)
-[![Actions Status: e-Navigator](https://github.com/hayat01sh1da/tutorials/workflows/e-Navigator/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22e-Navigator%22)
-[![Actions Status: Perfect Ruby on Rails](https://github.com/hayat01sh1da/tutorials/workflows/Perfect%20Ruby%20on%20Rails/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22Perfect%20Ruby%20on%20Rails%22)
-[![Actions Status: RESTful API](https://github.com/hayat01sh1da/tutorials/workflows/RESTful%20API/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22RESTful%20API%22)
+[![Actions Status: Ruby on Rails - e-Navigator](https://github.com/hayat01sh1da/tutorials/workflows/Ruby%20on%20Rails%20-%20e-Navigator/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22Ruby%20on%20Rails%20-%20e-Navigator%22)
+[![Actions Status: Ruby on Rails - Perfect Ruby on Rails](https://github.com/hayat01sh1da/tutorials/workflows/Ruby%20on%20Rails%20-%20Perfect%20Ruby%20on%20Rails/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22Ruby%20on%20Rails%20-%20Perfect%20Ruby%20on%20Rails%22)
+[![Actions Status: Ruby on Rails - RESTful API](https://github.com/hayat01sh1da/tutorials/workflows/Ruby%20on%20Rails%20-%20RESTful%20API/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22Ruby%20on%20Rails%20-%20RESTful%20API%22)
 [![Actions Status: TypeScript](https://github.com/hayat01sh1da/tutorials/workflows/TypeScript/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22TypeScript%22)
 [![Actions Status: CodeQL](https://github.com/hayat01sh1da/tutorials/workflows/CodeQL/badge.svg)](https://github.com/hayat01sh1da/tutorials/actions?query=workflow%3A%22CodeQL%22)
 

--- a/ruby-on-rails/e-navigator/Gemfile
+++ b/ruby-on-rails/e-navigator/Gemfile
@@ -29,7 +29,15 @@ gem 'dotenv-rails', '~> 3.2.0'
 gem 'bootsnap', '~> 1.23.0', require: false
 
 group :development, :test do
+  # Debug tool used with binding.irb. Explicit require avoids eager loading `debug/prelude`
+  # which interferes with the Docker boot process.
+  # [Ref] https://ruby.github.io/irb/#label-Debugging+with+IRB
+  # [Ref] https://github.com/ruby/debug#debug-command-on-the-debug-console
+  # [Ref] https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri windows ], require: false
+  # Typechecking
+  gem 'rbs-inline', '~> 0.13.0', require: false
+  gem 'steep', '~> 1.10.0', require: false
 end
 
 group :development do

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
@@ -99,6 +100,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -123,6 +125,8 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    ffi (1.17.4-x86_64-linux-gnu)
+    fileutils (1.8.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -141,6 +145,11 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.19.3)
+    language_server-protocol (3.17.0.5)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -158,6 +167,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    mutex_m (0.3.0)
     mysql2 (0.5.7)
       bigdecimal
     net-imap (0.6.3)
@@ -173,6 +183,9 @@ GEM
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -230,7 +243,17 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (3.10.4)
+      logger
+      tsort
+    rbs-inline (0.13.0)
+      prism (>= 0.29)
+      rbs (>= 3.8.0)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -250,7 +273,27 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    steep (1.10.0)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      mutex_m (>= 0.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 3.9)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
     stringio (3.2.0)
+    strscan (3.1.8)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -259,6 +302,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
     warden (1.2.9)
@@ -298,7 +344,9 @@ DEPENDENCIES
   puma (~> 8.0.0)
   rails (~> 8.1.3)
   rails-controller-testing (~> 1.0.5)
+  rbs-inline (~> 0.13.0)
   selenium-webdriver (~> 4.43.0)
+  steep (~> 1.10.0)
   turbo-rails (~> 2.0.16)
   tzinfo-data
   web-console (~> 4.3.0)
@@ -317,6 +365,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
@@ -329,6 +378,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   devise (5.0.3) sha256=c4c065051cdc4ace11547b2b7f5c3c4c97d0f1269250f5fe90f614ff78f29546
@@ -340,6 +390,8 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -347,6 +399,8 @@ CHECKSUMS
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
@@ -355,6 +409,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.3) sha256=88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   mysql2 (0.5.7) sha256=ba09ede515a0ae8a7192040a1b778c0fb0f025fa5877e9be895cd325fa5e9d7b
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
@@ -363,6 +418,7 @@ CHECKSUMS
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
@@ -380,7 +436,12 @@ CHECKSUMS
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rbs (3.10.4) sha256=b17d7c4be4bb31a11a3b529830f0aa206a807ca42f2e7921a3027dfc6b7e5ce8
+  rbs-inline (0.13.0) sha256=aba6e48c2d1b75276e8557376164f4b4ba96dd0204e779a5cee2af442bd30442
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
@@ -389,12 +450,17 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
+  steep (1.10.0) sha256=1b295b55f9aaff1b8d3ee42453ee55bc2a1078fda0268f288edb2dc014f4d7d1
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0

--- a/ruby-on-rails/e-navigator/Steepfile
+++ b/ruby-on-rails/e-navigator/Steepfile
@@ -1,0 +1,11 @@
+D = Steep::Diagnostic
+
+target :app do
+  check "app"
+  check "test"
+  signature "sig"
+
+  library "minitest"
+
+  configure_code_diagnostics(D::Ruby.default)
+end

--- a/ruby-on-rails/e-navigator/app/controllers/application_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!

--- a/ruby-on-rails/e-navigator/app/controllers/interviews_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/interviews_controller.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class InterviewsController < ApplicationController
   before_action :set_user, only: [:index, :new, :create, :select_approver]
   before_action :set_interview, only: [:edit, :update, :destroy, :approve]

--- a/ruby-on-rails/e-navigator/app/controllers/users/confirmations_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users/confirmations_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Users::ConfirmationsController < Devise::ConfirmationsController
   # GET /resource/confirmation/new

--- a/ruby-on-rails/e-navigator/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should configure your model like this:

--- a/ruby-on-rails/e-navigator/app/controllers/users/passwords_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users/passwords_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Users::PasswordsController < Devise::PasswordsController
   # GET /resource/password/new

--- a/ruby-on-rails/e-navigator/app/controllers/users/registrations_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]

--- a/ruby-on-rails/e-navigator/app/controllers/users/sessions_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users/sessions_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]

--- a/ruby-on-rails/e-navigator/app/controllers/users/unlocks_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users/unlocks_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Users::UnlocksController < Devise::UnlocksController
   # GET /resource/unlock/new

--- a/ruby-on-rails/e-navigator/app/controllers/users_controller.rb
+++ b/ruby-on-rails/e-navigator/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class UsersController < ApplicationController
   # GET /users
   def index

--- a/ruby-on-rails/e-navigator/app/helpers/application_helper.rb
+++ b/ruby-on-rails/e-navigator/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 module ApplicationHelper
 
   def devise_mapping

--- a/ruby-on-rails/e-navigator/app/helpers/home_helper.rb
+++ b/ruby-on-rails/e-navigator/app/helpers/home_helper.rb
@@ -1,2 +1,3 @@
+# rbs_inline: enabled
 module HomeHelper
 end

--- a/ruby-on-rails/e-navigator/app/helpers/interviews_helper.rb
+++ b/ruby-on-rails/e-navigator/app/helpers/interviews_helper.rb
@@ -1,2 +1,3 @@
+# rbs_inline: enabled
 module InterviewsHelper
 end

--- a/ruby-on-rails/e-navigator/app/jobs/application_job.rb
+++ b/ruby-on-rails/e-navigator/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
+# rbs_inline: enabled
 class ApplicationJob < ActiveJob::Base
 end

--- a/ruby-on-rails/e-navigator/app/mailers/application_mailer.rb
+++ b/ruby-on-rails/e-navigator/app/mailers/application_mailer.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class ApplicationMailer < ActionMailer::Base
   default from: 'reminder@example.com'
   layout 'mailer'

--- a/ruby-on-rails/e-navigator/app/mailers/interview_mailer.rb
+++ b/ruby-on-rails/e-navigator/app/mailers/interview_mailer.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class InterviewMailer < ApplicationMailer
   helper ApplicationHelper
 

--- a/ruby-on-rails/e-navigator/app/models/application_record.rb
+++ b/ruby-on-rails/e-navigator/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/ruby-on-rails/e-navigator/app/models/interview.rb
+++ b/ruby-on-rails/e-navigator/app/models/interview.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class Interview < ApplicationRecord
   belongs_to :user
   validates :user_id, presence: true

--- a/ruby-on-rails/e-navigator/app/models/user.rb
+++ b/ruby-on-rails/e-navigator/app/models/user.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/application_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/application_controller.rbs
@@ -1,0 +1,6 @@
+# Generated from app/controllers/application_controller.rb with RBS::Inline
+
+# rbs_inline: enabled
+class ApplicationController < ActionController::Base
+  def configure_permitted_parameters: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/interviews_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/interviews_controller.rbs
@@ -1,0 +1,40 @@
+# Generated from app/controllers/interviews_controller.rb with RBS::Inline
+
+# rbs_inline: enabled
+class InterviewsController < ApplicationController
+  # GET /users/:user_id/interviews
+  def index: () -> untyped
+
+  # GET /users/:user_id/interviews/new
+  def new: () -> untyped
+
+  # POST /users/:user_id/interviews
+  def create: () -> untyped
+
+  # GET /users/:user_id/interviews/:id/edit
+  def edit: () -> untyped
+
+  # PATCH /users/:user_id/interviews/:id
+  def update: () -> untyped
+
+  # DELETE /users/:user_id/interviews/:id
+  def destroy: () -> untyped
+
+  # POST /users/:user_id/interviews/select_approver
+  def select_approver: () -> untyped
+
+  # POST /users/:user_id/interviews/:id/approve
+  def approve: () -> untyped
+
+  private
+
+  def set_user: () -> untyped
+
+  def set_interview: () -> untyped
+
+  def interview_params: () -> untyped
+
+  def approver_params: () -> untyped
+
+  def current_user?: (untyped id) -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/confirmations_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/confirmations_controller.rbs
@@ -1,0 +1,4 @@
+# Generated from app/controllers/users/confirmations_controller.rb with RBS::Inline
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/omniauth_callbacks_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/omniauth_callbacks_controller.rbs
@@ -1,0 +1,4 @@
+# Generated from app/controllers/users/omniauth_callbacks_controller.rb with RBS::Inline
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/passwords_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/passwords_controller.rbs
@@ -1,0 +1,20 @@
+# Generated from app/controllers/users/passwords_controller.rb with RBS::Inline
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  def new: () -> untyped
+
+  # POST /resource/password
+  def create: () -> untyped
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  def edit: () -> untyped
+
+  # PUT /resource/password
+  def update: () -> untyped
+
+  def after_resetting_password_path_for: (untyped resource) -> untyped
+
+  # The path used after sending reset password instructions
+  def after_sending_reset_password_instructions_path_for: (untyped resource_name) -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/registrations_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/registrations_controller.rbs
@@ -1,0 +1,7 @@
+# Generated from app/controllers/users/registrations_controller.rb with RBS::Inline
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  def after_update_path_for: (untyped resource) -> untyped
+
+  def update_resource: (untyped resource, untyped params) -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/sessions_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/sessions_controller.rbs
@@ -1,0 +1,7 @@
+# Generated from app/controllers/users/sessions_controller.rb with RBS::Inline
+
+class Users::SessionsController < Devise::SessionsController
+  def after_sign_in_path_for: (untyped resource) -> untyped
+
+  def after_sign_out_path_for: (untyped resource) -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/unlocks_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users/unlocks_controller.rbs
@@ -1,0 +1,4 @@
+# Generated from app/controllers/users/unlocks_controller.rb with RBS::Inline
+
+class Users::UnlocksController < Devise::UnlocksController
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/controllers/users_controller.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/controllers/users_controller.rbs
@@ -1,0 +1,10 @@
+# Generated from app/controllers/users_controller.rb with RBS::Inline
+
+# rbs_inline: enabled
+class UsersController < ApplicationController
+  # GET /users
+  def index: () -> untyped
+
+  # GET /users/:id
+  def show: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/helpers/application_helper.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/helpers/application_helper.rbs
@@ -1,0 +1,6 @@
+# Generated from app/helpers/application_helper.rb with RBS::Inline
+
+# rbs_inline: enabled
+module ApplicationHelper
+  def devise_mapping: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/helpers/home_helper.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/helpers/home_helper.rbs
@@ -1,0 +1,5 @@
+# Generated from app/helpers/home_helper.rb with RBS::Inline
+
+# rbs_inline: enabled
+module HomeHelper
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/helpers/interviews_helper.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/helpers/interviews_helper.rbs
@@ -1,0 +1,5 @@
+# Generated from app/helpers/interviews_helper.rb with RBS::Inline
+
+# rbs_inline: enabled
+module InterviewsHelper
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/jobs/application_job.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/jobs/application_job.rbs
@@ -1,0 +1,5 @@
+# Generated from app/jobs/application_job.rb with RBS::Inline
+
+# rbs_inline: enabled
+class ApplicationJob < ActiveJob::Base
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/mailers/application_mailer.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/mailers/application_mailer.rbs
@@ -1,0 +1,5 @@
+# Generated from app/mailers/application_mailer.rb with RBS::Inline
+
+# rbs_inline: enabled
+class ApplicationMailer < ActionMailer::Base
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/mailers/interview_mailer.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/mailers/interview_mailer.rbs
@@ -1,0 +1,10 @@
+# Generated from app/mailers/interview_mailer.rb with RBS::Inline
+
+# rbs_inline: enabled
+class InterviewMailer < ApplicationMailer
+  # メソッド名を変更しました
+  def apply: (untyped user, untyped approver) -> untyped
+
+  # メソッド名を変更しました
+  def approve: (untyped approver, untyped interview) -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/models/application_record.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/models/application_record.rbs
@@ -1,0 +1,5 @@
+# Generated from app/models/application_record.rb with RBS::Inline
+
+# rbs_inline: enabled
+class ApplicationRecord < ActiveRecord::Base
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/models/interview.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/models/interview.rbs
@@ -1,0 +1,6 @@
+# Generated from app/models/interview.rb with RBS::Inline
+
+# rbs_inline: enabled
+class Interview < ApplicationRecord
+  def datetime_cannot_be_in_the_past: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/app/models/user.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/app/models/user.rbs
@@ -1,0 +1,23 @@
+# Generated from app/models/user.rb with RBS::Inline
+
+# rbs_inline: enabled
+class User < ApplicationRecord
+  # パスワード入力なしでの更新を許可する
+  def update_without_current_password: (untyped params, *untyped options) -> untyped
+
+  def age: () -> untyped
+
+  private
+
+  attr_reader today: untyped
+
+  attr_reader birth_date: untyped
+
+  def birthday_cannot_be_in_the_future: () -> untyped
+
+  def before_birth_date_on_birth_month?: () -> untyped
+
+  def before_birthday?: () -> untyped
+
+  def before_birth_month?: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/controllers/application_controller_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/controllers/application_controller_test.rbs
@@ -1,0 +1,7 @@
+# Generated from test/controllers/application_controller_test.rb with RBS::Inline
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  def setup: () -> untyped
+
+  private
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/controllers/interviews_controller_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/controllers/interviews_controller_test.rbs
@@ -1,0 +1,7 @@
+# Generated from test/controllers/interviews_controller_test.rb with RBS::Inline
+
+class InterviewsControllerTest < ActionDispatch::IntegrationTest
+  def setup: () -> untyped
+
+  private
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/controllers/users_controller_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/controllers/users_controller_test.rbs
@@ -1,0 +1,7 @@
+# Generated from test/controllers/users_controller_test.rb with RBS::Inline
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup: () -> untyped
+
+  private
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/helpers/application_helper_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/helpers/application_helper_test.rbs
@@ -1,0 +1,4 @@
+# Generated from test/helpers/application_helper_test.rb with RBS::Inline
+
+class ApplicationHelperTest < ActionView::TestCase
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/integration/interview_flow_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/integration/interview_flow_test.rbs
@@ -1,0 +1,5 @@
+# Generated from test/integration/interview_flow_test.rb with RBS::Inline
+
+class InterviewFlowTest < ActionDispatch::IntegrationTest
+  def setup: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/integration/user_flow_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/integration/user_flow_test.rbs
@@ -1,0 +1,5 @@
+# Generated from test/integration/user_flow_test.rb with RBS::Inline
+
+class UserFlowTest < ActionDispatch::IntegrationTest
+  def setup: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/jobs/application_job_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/jobs/application_job_test.rbs
@@ -1,0 +1,4 @@
+# Generated from test/jobs/application_job_test.rb with RBS::Inline
+
+class ApplicationJobTest < ActiveJob::TestCase
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/mailers/application_mailer_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/mailers/application_mailer_test.rbs
@@ -1,0 +1,4 @@
+# Generated from test/mailers/application_mailer_test.rb with RBS::Inline
+
+class ApplicationMailerTest < ActionMailer::TestCase
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/mailers/interview_mailer_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/mailers/interview_mailer_test.rbs
@@ -1,0 +1,5 @@
+# Generated from test/mailers/interview_mailer_test.rb with RBS::Inline
+
+class InterviewMailerTest < ActionMailer::TestCase
+  def setup: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/models/application_record_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/models/application_record_test.rbs
@@ -1,0 +1,4 @@
+# Generated from test/models/application_record_test.rb with RBS::Inline
+
+class ApplicationRecordTest < ActiveSupport::TestCase
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/models/interview_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/models/interview_test.rbs
@@ -1,0 +1,5 @@
+# Generated from test/models/interview_test.rb with RBS::Inline
+
+class InterviewTest < ActiveSupport::TestCase
+  def setup: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/models/user_test.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/models/user_test.rbs
@@ -1,0 +1,5 @@
+# Generated from test/models/user_test.rb with RBS::Inline
+
+class UserTest < ActiveSupport::TestCase
+  def setup: () -> untyped
+end

--- a/ruby-on-rails/e-navigator/sig/generated/test/test_helper.rbs
+++ b/ruby-on-rails/e-navigator/sig/generated/test/test_helper.rbs
@@ -1,0 +1,13 @@
+# Generated from test/test_helper.rb with RBS::Inline
+
+class ActiveSupport::TestCase
+  include Devise::Test::IntegrationHelpers
+end
+
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end
+
+class ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+end

--- a/ruby-on-rails/e-navigator/test/controllers/application_controller_test.rb
+++ b/ruby-on-rails/e-navigator/test/controllers/application_controller_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class ApplicationControllerTest < ActionDispatch::IntegrationTest

--- a/ruby-on-rails/e-navigator/test/controllers/interviews_controller_test.rb
+++ b/ruby-on-rails/e-navigator/test/controllers/interviews_controller_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class InterviewsControllerTest < ActionDispatch::IntegrationTest

--- a/ruby-on-rails/e-navigator/test/controllers/users_controller_test.rb
+++ b/ruby-on-rails/e-navigator/test/controllers/users_controller_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest

--- a/ruby-on-rails/e-navigator/test/helpers/application_helper_test.rb
+++ b/ruby-on-rails/e-navigator/test/helpers/application_helper_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase

--- a/ruby-on-rails/e-navigator/test/integration/interview_flow_test.rb
+++ b/ruby-on-rails/e-navigator/test/integration/interview_flow_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class InterviewFlowTest < ActionDispatch::IntegrationTest

--- a/ruby-on-rails/e-navigator/test/integration/user_flow_test.rb
+++ b/ruby-on-rails/e-navigator/test/integration/user_flow_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class UserFlowTest < ActionDispatch::IntegrationTest

--- a/ruby-on-rails/e-navigator/test/jobs/application_job_test.rb
+++ b/ruby-on-rails/e-navigator/test/jobs/application_job_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class ApplicationJobTest < ActiveJob::TestCase

--- a/ruby-on-rails/e-navigator/test/mailers/application_mailer_test.rb
+++ b/ruby-on-rails/e-navigator/test/mailers/application_mailer_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class ApplicationMailerTest < ActionMailer::TestCase

--- a/ruby-on-rails/e-navigator/test/mailers/interview_mailer_test.rb
+++ b/ruby-on-rails/e-navigator/test/mailers/interview_mailer_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class InterviewMailerTest < ActionMailer::TestCase

--- a/ruby-on-rails/e-navigator/test/models/application_record_test.rb
+++ b/ruby-on-rails/e-navigator/test/models/application_record_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class ApplicationRecordTest < ActiveSupport::TestCase

--- a/ruby-on-rails/e-navigator/test/models/interview_test.rb
+++ b/ruby-on-rails/e-navigator/test/models/interview_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class InterviewTest < ActiveSupport::TestCase

--- a/ruby-on-rails/e-navigator/test/models/user_test.rb
+++ b/ruby-on-rails/e-navigator/test/models/user_test.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase

--- a/ruby-on-rails/e-navigator/test/test_helper.rb
+++ b/ruby-on-rails/e-navigator/test/test_helper.rb
@@ -1,3 +1,4 @@
+# rbs_inline: enabled
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'


### PR DESCRIPTION
## 1. Why (Purpose)

Introducing **rbs-inline** + **Steep** brings static type checking to Ruby/Rails codebases that otherwise rely entirely on runtime behavior. The goals are:

- **Reliability** — Catch type mismatches, nil errors, and argument arity bugs *before* running code or tests
- **Maintainability** — Type signatures serve as machine-verifiable documentation, making refactoring safer and onboarding easier
- **Incremental adoption** — The `# rbs_inline: enabled` opt-in comment lets you roll it out file-by-file without disrupting existing code

## 2. What (Procedures)

### 2-1. Scope

12 projects total — 8 pure Ruby CLI projects and 4 Rails projects.

| # | Project | Type | Files typed |
|---|---------|------|--:|
| 1 | `coding-tests/ruby` | Ruby CLI | 18 |
| 2 | `pr-title-printers/ruby` | Ruby CLI | 3 |
| 3 | `json-data-sorters/ruby` | Ruby CLI | 4 |
| 4 | `itunes-file-delimiter-replacer/ruby` | Ruby CLI | 3 |
| 5 | `template-creators/ruby` | Ruby CLI | 3 |
| 6 | `file-extension-converters/ruby` | Ruby CLI | 3 |
| 7 | `file-cleaners/ruby` | Ruby CLI | 3 |
| 8 | `github-wiki-organisers/ruby` | Ruby CLI | 13 |
| 9 | `tutorials/.../restful-api` | Rails | 40 |
| 10 | `tutorials/.../perfect-ruby-on-rails` | Rails | 26 |
| 11 | `tutorials/.../e-navigator` | Rails | 31 |
| 12 | `botpress-accuracy-checkers/ruby-on-rails` | Rails | 20 |
| | **Total** | | **167** |

### 2-2. Steps performed

1. **Added `rbs-inline` and `steep` gems** to each Rails project's `Gemfile` (in `:development, :test` group with `require: false`)
2. **Added `# rbs_inline: enabled`** magic comment to every `.rb` file under `app/`, `spec/`, `test/`, `src/`, `exec/` — respecting existing `# frozen_string_literal: true` placement
3. **Generated RBS signatures** via `rbs-inline` → output stored in `sig/generated/` mirroring source tree
4. **Created/updated `Steepfile`** in each project root, declaring:
   - `check` targets (source + test directories)
   - `signature "sig"` for generated `.rbs` files
   - `library` entries for stdlib/gems with RBS definitions (e.g. `minitest`, `csv`, `json`, `fileutils`, `net-smtp`, `observer`, `ostruct`, `psych`)

### 2-3. Steepfile library declarations per project

| # | Project | Libraries |
|---|---------|-----------|
| 1 | botpress-accuracy-checkers (Rails) | `csv`, `ostruct` |
| 2 | restful-api (Rails) | `net-smtp`, `observer`, `ostruct` |
| 3 | perfect-ruby-on-rails (Rails) | `minitest`, `net-smtp`, `observer`, `ostruct`, `psych` |
| 4 | e-navigator (Rails) | `minitest` |
| 5 | coding-tests | `json`, `net-http` |
| 6 | json-data-sorters | `fileutils`, `json` |
| 7 | template-creators | `date`, `fileutils` |
| 8 | itunes-file-delimiter-replacer | `fileutils` |
| 9 | file-extension-converters | `fileutils` |
| 10 | file-cleaners | `fileutils` |
| 11 | github-wiki-organisers | `fileutils` |
| 12 | pr-title-printers | *(none)* |

## 3. How (Operation and Maintenance)

### 3-1. Regenerating signatures after code changes

```bash
bundle exec rbs-inline --output sig/generated app/   # Rails: app code
bundle exec rbs-inline --output sig/generated spec/   # Rails: spec code
bundle exec rbs-inline --output sig/generated test/   # Rails: test code
```

For pure Ruby projects (no Bundler): `rbs-inline --output sig/generated src/ exec/ test/`

### 3-2. Running type checks

```bash
bundle exec steep check   # Rails projects
steep check               # pure Ruby projects
```

### 3-3. When adding new files

1. Add `# rbs_inline: enabled` as the first line (after `# frozen_string_literal: true` if present)
2. Re-run `rbs-inline` to generate the `.rbs` file
3. Run `steep check` to verify

### 3-4. When adding new gems

If a new gem provides RBS types (check [ruby/gem_rbs_collection](https://github.com/ruby/gem_rbs_collection)), add a `library "<gem>"` entry to `Steepfile`.

## 4. Pros & Cons

### 4-1. Pros

| # | Advantage | Detail |
|---|-----------|--------|
| 1 | **Early bug detection** | Catches `NoMethodError`, nil misuse, wrong argument types at analysis time |
| 2 | **Living documentation** | `.rbs` signatures stay in sync with code via `rbs-inline` regeneration |
| 3 | **Incremental adoption** | Per-file opt-in with `# rbs_inline: enabled` — no big-bang migration |
| 4 | **Zero runtime overhead** | All checking happens offline; no performance cost in production |
| 5 | **IDE integration** | Steep provides editor feedback (completion, hover types) in supported editors |

### 4-2. Cons

| # | Disadvantage | Detail |
|---|--------------|--------|
| 1 | **Manual regeneration** | No Rake task automation yet — developers must remember to run `rbs-inline` after changes |
| 2 | **Limited gem coverage** | Many Rails gems (Devise, FactoryBot, Faker, etc.) lack RBS definitions — Steep cannot type-check across those boundaries |
| 3 | **Generated sigs are shallow** | Without explicit type annotations in source, generated `.rbs` files contain only structure (class/module/method names) with `untyped` signatures |
| 4 | **Learning curve** | Developers need to learn RBS annotation syntax to get full value |
| 5 | **CI integration needed** | Currently no CI step enforces `steep check` — regressions can slip through |