### PR TITLE
[ruby] Fix Invalid Paths Filters on GitHub Actions

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        cache: npm
+        cache: pnpm
     - name: Install pnpm
       shell: bash
       run: corepack enable && corepack prepare pnpm@latest --activate

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -12,8 +12,6 @@ runs:
     # change this to (see https://github.com/actions/setup-node#usage):
     - name: Set up Node.js
       uses: actions/setup-node@v6
-      with:
-        cache: pnpm
     - name: Install pnpm
       shell: bash
       run: corepack enable && corepack prepare pnpm@latest --activate

--- a/.github/actions/setup-ruby-on-rails/action.yml
+++ b/.github/actions/setup-ruby-on-rails/action.yml
@@ -24,7 +24,7 @@ runs:
         bundle config set --local path 'vendor/bundle'
         bundle install
     - name: Set up Database
-      if: ${{ inputs.job-name == 'Minitest' || inputs.job-name == 'RSpec' }}
+      if: ${{ inputs.job-name == 'minitest' || inputs.job-name == 'RSpec' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |

--- a/.github/workflows/e-navigator.yml
+++ b/.github/workflows/e-navigator.yml
@@ -13,7 +13,7 @@ on:
       - master
     paths:
       - .github/actions/setup-ruby-on-rails/action.yml
-      - .github/workflows/minitest--e-navigator.yml
+      - .github/workflows/e-navigator.yml
       - .ruby-version
       - ruby-on-rails/e-navigator/.ruby-version
       - ruby-on-rails/e-navigator/Gemfile
@@ -33,7 +33,7 @@ on:
   pull_request:
     paths:
       - .github/actions/setup-ruby-on-rails/action.yml
-      - .github/workflows/minitest--e-navigator.yml
+      - .github/workflows/e-navigator.yml
       - .ruby-version
       - ruby-on-rails/e-navigator/.ruby-version
       - ruby-on-rails/e-navigator/Gemfile
@@ -71,7 +71,7 @@ jobs:
           filters: |
             ruby:
               - .github/actions/setup-ruby-on-rails/action.yml
-              - .github/workflows/minitest--e-navigator.yml
+              - .github/workflows/e-navigator.yml
               - .ruby-version
               - ruby-on-rails/e-navigator/.ruby-version
               - ruby-on-rails/e-navigator/Gemfile
@@ -86,7 +86,7 @@ jobs:
               - ruby-on-rails/e-navigator/**/*.html.erb
             rubocop:
               - .github/actions/setup-ruby-on-rails/action.yml
-              - .github/workflows/minitest--e-navigator.yml
+              - .github/workflows/e-navigator.yml
               - .ruby-version
               - ruby-on-rails/e-navigator/.ruby-version
               - ruby-on-rails/e-navigator/Gemfile
@@ -98,7 +98,7 @@ jobs:
               - ruby-on-rails/e-navigator/**/*.rake
             # steep:
               # - .github/actions/setup-ruby-on-rails/action.yml
-              # - .github/workflows/minitest--e-navigator.yml
+              # - .github/workflows/e-navigator.yml
               # - .ruby-version
               # - ruby-on-rails/e-navigator/.ruby-version
               # - ruby-on-rails/e-navigator/Gemfile

--- a/.github/workflows/e-navigator.yml
+++ b/.github/workflows/e-navigator.yml
@@ -59,9 +59,9 @@ jobs:
   change-detection:
     runs-on: ubuntu-latest
     outputs:
-      ruby-changes: ${{ steps.ruby.outputs.changes }}
-      rubocop-changes: ${{ steps.rubocop.outputs.changes }}
-      # steep-changes: ${{ steps.steep.outputs.changes }}
+      ruby-changes: ${{ steps.change-detection.outputs.ruby }}
+      rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
+      # steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
       - uses: actions/checkout@v6
       - name: Change Detection

--- a/.github/workflows/e-navigator.yml
+++ b/.github/workflows/e-navigator.yml
@@ -69,45 +69,45 @@ jobs:
         id: change-detection
         with:
           filters: |
-            ruby: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/minitest--e-navigator.yml
-              .ruby-version
-              ruby-on-rails/e-navigator/.ruby-version
-              ruby-on-rails/e-navigator/Gemfile
-              ruby-on-rails/e-navigator/Gemfile.lock
-              ruby-on-rails/e-navigator/Rakefile
-              ruby-on-rails/e-navigator/**/*.rb
-              ruby-on-rails/e-navigator/**/*.rake
-              ruby-on-rails/e-navigator/**/*.yml
-              ruby-on-rails/e-navigator/**/*.js
-              ruby-on-rails/e-navigator/**/*.scss
-              ruby-on-rails/e-navigator/**/*.css
-              ruby-on-rails/e-navigator/**/*.html.erb
-            rubocop: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/minitest--e-navigator.yml
-              .ruby-version
-              ruby-on-rails/e-navigator/.ruby-version
-              ruby-on-rails/e-navigator/Gemfile
-              ruby-on-rails/e-navigator/Gemfile.lock
-              ruby-on-rails/e-navigator/Rakefile
-              ruby-on-rails/e-navigator/rubocop.yml
-              ruby-on-rails/e-navigator/rubocop_todo.yml
-              ruby-on-rails/e-navigator/**/*.rb
-              ruby-on-rails/e-navigator/**/*.rake
-            # steep: |
-            #   .github/actions/setup-ruby-on-rails/action.yml
-            #   .github/workflows/minitest--e-navigator.yml
-            #   .ruby-version
-            #   ruby-on-rails/e-navigator/.ruby-version
-            #   ruby-on-rails/e-navigator/Gemfile
-            #   ruby-on-rails/e-navigator/Gemfile.lock
-            #   ruby-on-rails/e-navigator/Rakefile
-            #   ruby-on-rails/e-navigator/Steepfile
-            #   ruby-on-rails/e-navigator/**/*.rb
-            #   ruby-on-rails/e-navigator/**/*.rbs
-            #   ruby-on-rails/e-navigator/**/*.rake
+            ruby:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/minitest--e-navigator.yml
+              - .ruby-version
+              - ruby-on-rails/e-navigator/.ruby-version
+              - ruby-on-rails/e-navigator/Gemfile
+              - ruby-on-rails/e-navigator/Gemfile.lock
+              - ruby-on-rails/e-navigator/Rakefile
+              - ruby-on-rails/e-navigator/**/*.rb
+              - ruby-on-rails/e-navigator/**/*.rake
+              - ruby-on-rails/e-navigator/**/*.yml
+              - ruby-on-rails/e-navigator/**/*.js
+              - ruby-on-rails/e-navigator/**/*.scss
+              - ruby-on-rails/e-navigator/**/*.css
+              - ruby-on-rails/e-navigator/**/*.html.erb
+            rubocop:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/minitest--e-navigator.yml
+              - .ruby-version
+              - ruby-on-rails/e-navigator/.ruby-version
+              - ruby-on-rails/e-navigator/Gemfile
+              - ruby-on-rails/e-navigator/Gemfile.lock
+              - ruby-on-rails/e-navigator/Rakefile
+              - ruby-on-rails/e-navigator/rubocop.yml
+              - ruby-on-rails/e-navigator/rubocop_todo.yml
+              - ruby-on-rails/e-navigator/**/*.rb
+              - ruby-on-rails/e-navigator/**/*.rake
+            # steep:
+              # - .github/actions/setup-ruby-on-rails/action.yml
+              # - .github/workflows/minitest--e-navigator.yml
+              # - .ruby-version
+              # - ruby-on-rails/e-navigator/.ruby-version
+              # - ruby-on-rails/e-navigator/Gemfile
+              # - ruby-on-rails/e-navigator/Gemfile.lock
+              # - ruby-on-rails/e-navigator/Rakefile
+              # - ruby-on-rails/e-navigator/Steepfile
+              # - ruby-on-rails/e-navigator/**/*.rb
+              # - ruby-on-rails/e-navigator/**/*.rbs
+              # - ruby-on-rails/e-navigator/**/*.rake
   minitest:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/e-navigator.yml
+++ b/.github/workflows/e-navigator.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator
-          job-name: Minitest
+          job-name: minitest
       - name: Minitest
         working-directory: ./ruby-on-rails/e-navigator
         run: bin/rails test
@@ -132,7 +132,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator
-          job-name: Brakeman
+          job-name: brakeman
       - name: Brakeman
         working-directory: ./ruby-on-rails/e-navigator
         run: bundle exec brakeman --no-pager
@@ -146,7 +146,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator
-          job-name: RuboCop
+          job-name: rubocop
       - name: RuboCop
         working-directory: ./ruby-on-rails/e-navigator
         run: bundle exec rubocop
@@ -160,7 +160,7 @@ jobs:
   #     - uses: ./.github/actions/setup-ruby-on-rails
   #       with:
   #         working-directory: ./ruby-on-rails/e-navigator
-  #         job-name: Steep
+  #         job-name: steep
   #     - name: Steep
   #       working-directory: ./ruby-on-rails/e-navigator
   #       run: |

--- a/.github/workflows/perfect-ruby-on-rails.yml
+++ b/.github/workflows/perfect-ruby-on-rails.yml
@@ -13,7 +13,7 @@ on:
       - master
     paths:
       - .github/actions/setup-ruby-on-rails/action.yml
-      - .github/workflows/minitest--perfect-ruby-on-rails.yml
+      - .github/workflows/perfect-ruby-on-rails.yml
       - .ruby-version
       - .node-version
       - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
@@ -36,7 +36,7 @@ on:
   pull_request:
     paths:
       - .github/actions/setup-ruby-on-rails/action.yml
-      - .github/workflows/minitest--perfect-ruby-on-rails.yml
+      - .github/workflows/perfect-ruby-on-rails.yml
       - .ruby-version
       - .node-version
       - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
@@ -76,7 +76,7 @@ jobs:
           filters: |
             ruby:
               - .github/actions/setup-ruby-on-rails/action.yml
-              - .github/workflows/minitest--perfect-ruby-on-rails.yml
+              - .github/workflows/perfect-ruby-on-rails.yml
               - .ruby-version
               - .node-version
               - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
@@ -93,7 +93,7 @@ jobs:
               - ruby-on-rails/perfect-ruby-on-rails/pnpm-lock.yaml
             rubocop:
               - .github/actions/setup-ruby-on-rails/action.yml
-              - .github/workflows/minitest--perfect-ruby-on-rails.yml
+              - .github/workflows/perfect-ruby-on-rails.yml
               - .ruby-version
               - .node-version
               - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
@@ -105,7 +105,7 @@ jobs:
               - ruby-on-rails/perfect-ruby-on-rails/**/*.rake
             # steep:
               # - .github/actions/setup-ruby-on-rails/action.yml
-              # - .github/workflows/minitest--perfect-ruby-on-rails.yml
+              # - .github/workflows/perfect-ruby-on-rails.yml
               # - .ruby-version
               # - .node-version
               # - ruby-on-rails/perfect-ruby-on-rails/.ruby-version

--- a/.github/workflows/perfect-ruby-on-rails.yml
+++ b/.github/workflows/perfect-ruby-on-rails.yml
@@ -74,47 +74,47 @@ jobs:
         id: change-detection
         with:
           filters: |
-            ruby: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/minitest--perfect-ruby-on-rails.yml
-              .ruby-version
-              .node-version
-              ruby-on-rails/perfect-ruby-on-rails/.ruby-version
-              ruby-on-rails/perfect-ruby-on-rails/Gemfile
-              ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
-              ruby-on-rails/perfect-ruby-on-rails/**/*.rb
-              ruby-on-rails/perfect-ruby-on-rails/**/*.rake
-              ruby-on-rails/perfect-ruby-on-rails/**/*.yml
-              ruby-on-rails/perfect-ruby-on-rails/**/*.js
-              ruby-on-rails/perfect-ruby-on-rails/**/*.scss
-              ruby-on-rails/perfect-ruby-on-rails/**/*.css
-              ruby-on-rails/perfect-ruby-on-rails/**/*.html.erb
-              ruby-on-rails/perfect-ruby-on-rails/package.json
-              ruby-on-rails/perfect-ruby-on-rails/pnpm-lock.yaml
-            rubocop: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/minitest--perfect-ruby-on-rails.yml
-              .ruby-version
-              .node-version
-              ruby-on-rails/perfect-ruby-on-rails/.ruby-version
-              ruby-on-rails/perfect-ruby-on-rails/Gemfile
-              ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
-              ruby-on-rails/perfect-ruby-on-rails/rubocop.yml
-              ruby-on-rails/perfect-ruby-on-rails/rubocop_todo.yml
-              ruby-on-rails/perfect-ruby-on-rails/**/*.rb
-              ruby-on-rails/perfect-ruby-on-rails/**/*.rake
-            # steep: |
-            #   .github/actions/setup-ruby-on-rails/action.yml
-            #   .github/workflows/minitest--perfect-ruby-on-rails.yml
-            #   .ruby-version
-            #   .node-version
-            #   ruby-on-rails/perfect-ruby-on-rails/.ruby-version
-            #   ruby-on-rails/perfect-ruby-on-rails/Gemfile
-            #   ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
-            #   ruby-on-rails/perfect-ruby-on-rails/Steepfile
-            #   ruby-on-rails/perfect-ruby-on-rails/**/*.rb
-            #   ruby-on-rails/perfect-ruby-on-rails/**/*.rbs
-            #   ruby-on-rails/perfect-ruby-on-rails/**/*.rake
+            ruby:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/minitest--perfect-ruby-on-rails.yml
+              - .ruby-version
+              - .node-version
+              - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
+              - ruby-on-rails/perfect-ruby-on-rails/Gemfile
+              - ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.rb
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.rake
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.yml
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.js
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.scss
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.css
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.html.erb
+              - ruby-on-rails/perfect-ruby-on-rails/package.json
+              - ruby-on-rails/perfect-ruby-on-rails/pnpm-lock.yaml
+            rubocop:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/minitest--perfect-ruby-on-rails.yml
+              - .ruby-version
+              - .node-version
+              - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
+              - ruby-on-rails/perfect-ruby-on-rails/Gemfile
+              - ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+              - ruby-on-rails/perfect-ruby-on-rails/rubocop.yml
+              - ruby-on-rails/perfect-ruby-on-rails/rubocop_todo.yml
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.rb
+              - ruby-on-rails/perfect-ruby-on-rails/**/*.rake
+            # steep:
+              # - .github/actions/setup-ruby-on-rails/action.yml
+              # - .github/workflows/minitest--perfect-ruby-on-rails.yml
+              # - .ruby-version
+              # - .node-version
+              # - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
+              # - ruby-on-rails/perfect-ruby-on-rails/Gemfile
+              # - ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+              # - ruby-on-rails/perfect-ruby-on-rails/Steepfile
+              # - ruby-on-rails/perfect-ruby-on-rails/**/*.rb
+              # - ruby-on-rails/perfect-ruby-on-rails/**/*.rbs
+              # - ruby-on-rails/perfect-ruby-on-rails/**/*.rake
   minitest:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/perfect-ruby-on-rails.yml
+++ b/.github/workflows/perfect-ruby-on-rails.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails
-          job-name: Minitest
+          job-name: minitest
       - name: Minitest
         env:
           OAUTH_CLIENT_ID: ${ vars.OAUTH_CLIENT_ID }
@@ -155,7 +155,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails
-          job-name: Brakeman
+          job-name: brakeman
       - name: Brakeman
         working-directory: ./ruby-on-rails/perfect-ruby-on-rails
         run: bundle exec brakeman --no-pager
@@ -169,7 +169,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails
-          job-name: RuboCop
+          job-name: rubocop
       - name: RuboCop
         working-directory: ./ruby-on-rails/perfect-ruby-on-rails
         run: bundle exec rubocop
@@ -183,7 +183,7 @@ jobs:
   #     - uses: ./.github/actions/setup-ruby-on-rails
   #       with:
   #         working-directory: ./ruby-on-rails/perfect-ruby-on-rails
-  #         job-name: Steep
+  #         job-name: steep
   #     - name: Steep
   #       working-directory: ./ruby-on-rails/perfect-ruby-on-rails
   #       run: |

--- a/.github/workflows/perfect-ruby-on-rails.yml
+++ b/.github/workflows/perfect-ruby-on-rails.yml
@@ -64,9 +64,9 @@ jobs:
   change-detection:
     runs-on: ubuntu-latest
     outputs:
-      ruby-changes: ${{ steps.ruby.outputs.changes }}
-      rubocop-changes: ${{ steps.rubocop.outputs.changes }}
-      # steep-changes: ${{ steps.steep.outputs.changes }}
+      ruby-changes: ${{ steps.change-detection.outputs.ruby }}
+      rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
+      # steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
       - uses: actions/checkout@v6
       - name: Change Detection

--- a/.github/workflows/restful-api.yml
+++ b/.github/workflows/restful-api.yml
@@ -51,9 +51,9 @@ jobs:
   change-detection:
     runs-on: ubuntu-latest
     outputs:
-      ruby-changes: ${{ steps.ruby.outputs.changes }}
-      rubocop-changes: ${{ steps.rubocop.outputs.changes }}
-      # steep-changes: ${{ steps.steep.outputs.changes }}
+      ruby-changes: ${{ steps.change-detection.outputs.ruby }}
+      rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
+      # steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
       - uses: actions/checkout@v6
       - name: Change Detection

--- a/.github/workflows/restful-api.yml
+++ b/.github/workflows/restful-api.yml
@@ -113,9 +113,6 @@ jobs:
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-nodejs
-        with:
-          working-directory: ./ruby-on-rails/restful-api
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api

--- a/.github/workflows/restful-api.yml
+++ b/.github/workflows/restful-api.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api
-          job-name: RSpec
+          job-name: rspec
       - name: RSpec
         working-directory: ./ruby-on-rails/restful-api
         run: bundle exec rspec
@@ -130,7 +130,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api
-          job-name: Brakeman
+          job-name: brakeman
       - name: Brakeman
         working-directory: ./ruby-on-rails/restful-api
         run: bundle exec brakeman --no-pager
@@ -144,7 +144,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api
-          job-name: RuboCop
+          job-name: rubocop
       - name: RuboCop
         working-directory: ./ruby-on-rails/restful-api
         run: bundle exec rubocop
@@ -158,7 +158,7 @@ jobs:
   #     - uses: ./.github/actions/setup-ruby-on-rails
   #       with:
   #         working-directory: ./ruby-on-rails/restful-api
-  #         job-name: Steep
+  #         job-name: steep
   #     - name: Steep
   #       working-directory: ./ruby-on-rails/restful-api
   #       run: |

--- a/.github/workflows/restful-api.yml
+++ b/.github/workflows/restful-api.yml
@@ -61,41 +61,41 @@ jobs:
         id: change-detection
         with:
           filters: |
-            ruby: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/restful-api.yml
-              .ruby-version
-              ruby-on-rails/restful-api/.ruby-version
-              ruby-on-rails/restful-api/Gemfile
-              ruby-on-rails/restful-api/Gemfile.lock
-              ruby-on-rails/restful-api/Rakefile
-              ruby-on-rails/restful-api/**/*.rb
-              ruby-on-rails/restful-api/**/*.rake
-              ruby-on-rails/restful-api/**/*.yml
-            rubocop: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/restful-api.yml
-              .ruby-version
-              ruby-on-rails/restful-api/.ruby-version
-              ruby-on-rails/restful-api/Gemfile
-              ruby-on-rails/restful-api/Gemfile.lock
-              ruby-on-rails/restful-api/Rakefile
-              ruby-on-rails/restful-api/rubocop.yml
-              ruby-on-rails/restful-api/rubocop_todo.yml
-              ruby-on-rails/restful-api/**/*.rb
-              ruby-on-rails/restful-api/**/*.rake
-            steep: |
-              .github/actions/setup-ruby-on-rails/action.yml
-              .github/workflows/restful-api.yml
-              .ruby-version
-              ruby-on-rails/restful-api/.ruby-version
-              ruby-on-rails/restful-api/Gemfile
-              ruby-on-rails/restful-api/Gemfile.lock
-              ruby-on-rails/restful-api/Rakefile
-              ruby-on-rails/restful-api/Steepfile
-              ruby-on-rails/restful-api/**/*.rb
-              ruby-on-rails/restful-api/**/*.rbs
-              ruby-on-rails/restful-api/**/*.rake
+            ruby:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/restful-api.yml
+              - .ruby-version
+              - ruby-on-rails/restful-api/.ruby-version
+              - ruby-on-rails/restful-api/Gemfile
+              - ruby-on-rails/restful-api/Gemfile.lock
+              - ruby-on-rails/restful-api/Rakefile
+              - ruby-on-rails/restful-api/**/*.rb
+              - ruby-on-rails/restful-api/**/*.rake
+              - ruby-on-rails/restful-api/**/*.yml
+            rubocop:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/restful-api.yml
+              - .ruby-version
+              - ruby-on-rails/restful-api/.ruby-version
+              - ruby-on-rails/restful-api/Gemfile
+              - ruby-on-rails/restful-api/Gemfile.lock
+              - ruby-on-rails/restful-api/Rakefile
+              - ruby-on-rails/restful-api/rubocop.yml
+              - ruby-on-rails/restful-api/rubocop_todo.yml
+              - ruby-on-rails/restful-api/**/*.rb
+              - ruby-on-rails/restful-api/**/*.rake
+            steep:
+              - .github/actions/setup-ruby-on-rails/action.yml
+              - .github/workflows/restful-api.yml
+              - .ruby-version
+              - ruby-on-rails/restful-api/.ruby-version
+              - ruby-on-rails/restful-api/Gemfile
+              - ruby-on-rails/restful-api/Gemfile.lock
+              - ruby-on-rails/restful-api/Rakefile
+              - ruby-on-rails/restful-api/Steepfile
+              - ruby-on-rails/restful-api/**/*.rb
+              - ruby-on-rails/restful-api/**/*.rbs
+              - ruby-on-rails/restful-api/**/*.rake
   rspec:
     timeout-minutes: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 1. Summary

Fixed invalid attrribute access on GitHub Actions workflows configuration files.
Even if the step detects changes in the target files, no jobs run, which should be fixed.

<img width="347" height="183" alt="Screenshot 2026-04-22 144146" src="https://github.com/user-attachments/assets/9252ac00-2ca8-4939-a452-e5c99c9c4bee" />

## 2. Changes

- [Fix invalid paths filters on GitHub Actions](https://github.com/hayat01sh1da/tutorials/pull/239/changes/31fed6715b4849554eb40777829f46997a09ccba)
- [Replace remove flag with explicit declaration for paths filters on GitHub Actions](https://github.com/hayat01sh1da/tutorials/pull/239/changes/12ebb50626e49c404bf7431302775751d8d8f451)