### PR TITLE
[ruby-on-rails] Replace Deprecated `require` with `plugins` on RuboCop Configuration

### DIFF
--- a/ruby-on-rails/e-navigator/.rubocop.yml
+++ b/ruby-on-rails/e-navigator/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Reference: https://github.com/rubocop/ruby-style-guide
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rails

--- a/ruby-on-rails/perfect-ruby-on-rails/.rubocop.yml
+++ b/ruby-on-rails/perfect-ruby-on-rails/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Reference: https://github.com/rubocop/ruby-style-guide
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rails

--- a/ruby-on-rails/restful-api/.rubocop.yml
+++ b/ruby-on-rails/restful-api/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Reference: https://github.com/rubocop/ruby-style-guide
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec


### PR DESCRIPTION
## Summary

Resolve the following warning.

```command
$ rubocop
rubocop-minitest extension supports plugin, specify `plugins: rubocop-minitest` instead of `require: rubocop-minitest` in /mnt/c/Users/binlh/Documents/development/tutorials/ruby-on-rails/e-navigator/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```