### PR TITLE
[ruby-on-rails] Add Hidden File Marker to RuboCop Configuration Files on Github Actions Workflow

### DIFF
--- a/.github/workflows/e-navigator.yml
+++ b/.github/workflows/e-navigator.yml
@@ -19,8 +19,8 @@ on:
       - ruby-on-rails/e-navigator/Gemfile
       - ruby-on-rails/e-navigator/Gemfile.lock
       - ruby-on-rails/e-navigator/Rakefile
-      - ruby-on-rails/e-navigator/rubocop.yml
-      - ruby-on-rails/e-navigator/rubocop_todo.yml
+      - ruby-on-rails/e-navigator/.rubocop.yml
+      - ruby-on-rails/e-navigator/.rubocop_todo.yml
       # - ruby-on-rails/e-navigator/Steepfile
       - ruby-on-rails/e-navigator/**/*.rb
       # - ruby-on-rails/e-navigator/**/*.rbs
@@ -39,8 +39,8 @@ on:
       - ruby-on-rails/e-navigator/Gemfile
       - ruby-on-rails/e-navigator/Gemfile.lock
       - ruby-on-rails/e-navigator/Rakefile
-      - ruby-on-rails/e-navigator/rubocop.yml
-      - ruby-on-rails/e-navigator/rubocop_todo.yml
+      - ruby-on-rails/e-navigator/.rubocop.yml
+      - ruby-on-rails/e-navigator/.rubocop_todo.yml
       # - ruby-on-rails/e-navigator/Steepfile
       - ruby-on-rails/e-navigator/**/*.rb
       # - ruby-on-rails/e-navigator/**/*.rbs
@@ -92,8 +92,8 @@ jobs:
               - ruby-on-rails/e-navigator/Gemfile
               - ruby-on-rails/e-navigator/Gemfile.lock
               - ruby-on-rails/e-navigator/Rakefile
-              - ruby-on-rails/e-navigator/rubocop.yml
-              - ruby-on-rails/e-navigator/rubocop_todo.yml
+              - ruby-on-rails/e-navigator/.rubocop.yml
+              - ruby-on-rails/e-navigator/.rubocop_todo.yml
               - ruby-on-rails/e-navigator/**/*.rb
               - ruby-on-rails/e-navigator/**/*.rake
             # steep:

--- a/.github/workflows/perfect-ruby-on-rails.yml
+++ b/.github/workflows/perfect-ruby-on-rails.yml
@@ -20,8 +20,8 @@ on:
       - ruby-on-rails/perfect-ruby-on-rails/Gemfile
       - ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
       - ruby-on-rails/perfect-ruby-on-rails/Rakefile
-      - ruby-on-rails/perfect-ruby-on-rails/rubocop.yml
-      - ruby-on-rails/perfect-ruby-on-rails/rubocop_todo.yml
+      - ruby-on-rails/perfect-ruby-on-rails/.rubocop.yml
+      - ruby-on-rails/perfect-ruby-on-rails/.rubocop_todo.yml
       # - ruby-on-rails/perfect-ruby-on-rails/Steepfile
       - ruby-on-rails/perfect-ruby-on-rails/**/*.rb
       # - ruby-on-rails/perfect-ruby-on-rails/**/*.rbs
@@ -42,8 +42,8 @@ on:
       - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
       - ruby-on-rails/perfect-ruby-on-rails/Gemfile
       - ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
-      - ruby-on-rails/perfect-ruby-on-rails/rubocop.yml
-      - ruby-on-rails/perfect-ruby-on-rails/rubocop_todo.yml
+      - ruby-on-rails/perfect-ruby-on-rails/.rubocop.yml
+      - ruby-on-rails/perfect-ruby-on-rails/.rubocop_todo.yml
       # - ruby-on-rails/perfect-ruby-on-rails/Steepfile
       - ruby-on-rails/perfect-ruby-on-rails/**/*.rb
       # - ruby-on-rails/perfect-ruby-on-rails/**/*.rbs
@@ -99,8 +99,8 @@ jobs:
               - ruby-on-rails/perfect-ruby-on-rails/.ruby-version
               - ruby-on-rails/perfect-ruby-on-rails/Gemfile
               - ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
-              - ruby-on-rails/perfect-ruby-on-rails/rubocop.yml
-              - ruby-on-rails/perfect-ruby-on-rails/rubocop_todo.yml
+              - ruby-on-rails/perfect-ruby-on-rails/.rubocop.yml
+              - ruby-on-rails/perfect-ruby-on-rails/.rubocop_todo.yml
               - ruby-on-rails/perfect-ruby-on-rails/**/*.rb
               - ruby-on-rails/perfect-ruby-on-rails/**/*.rake
             # steep:

--- a/.github/workflows/restful-api.yml
+++ b/.github/workflows/restful-api.yml
@@ -19,8 +19,8 @@ on:
       - ruby-on-rails/restful-api/Gemfile
       - ruby-on-rails/restful-api/Gemfile.lock
       - ruby-on-rails/restful-api/Rakefile
-      - ruby-on-rails/restful-api/rubocop.yml
-      - ruby-on-rails/restful-api/rubocop_todo.yml
+      - ruby-on-rails/restful-api/.rubocop.yml
+      - ruby-on-rails/restful-api/.rubocop_todo.yml
       # - ruby-on-rails/restful-api/Steepfile
       - ruby-on-rails/restful-api/**/*.rb
       # - ruby-on-rails/restful-api/**/*.rbs
@@ -35,8 +35,8 @@ on:
       - ruby-on-rails/restful-api/Gemfile
       - ruby-on-rails/restful-api/Gemfile.lock
       - ruby-on-rails/restful-api/Rakefile
-      - ruby-on-rails/restful-api/rubocop.yml
-      - ruby-on-rails/restful-api/rubocop_todo.yml
+      - ruby-on-rails/restful-api/.rubocop.yml
+      - ruby-on-rails/restful-api/.rubocop_todo.yml
       # - ruby-on-rails/restful-api/Steepfile
       - ruby-on-rails/restful-api/**/*.rb
       # - ruby-on-rails/restful-api/**/*.rbs
@@ -80,8 +80,8 @@ jobs:
               - ruby-on-rails/restful-api/Gemfile
               - ruby-on-rails/restful-api/Gemfile.lock
               - ruby-on-rails/restful-api/Rakefile
-              - ruby-on-rails/restful-api/rubocop.yml
-              - ruby-on-rails/restful-api/rubocop_todo.yml
+              - ruby-on-rails/restful-api/.rubocop.yml
+              - ruby-on-rails/restful-api/.rubocop_todo.yml
               - ruby-on-rails/restful-api/**/*.rb
               - ruby-on-rails/restful-api/**/*.rake
             steep:


### PR DESCRIPTION
## Summary

On Github Actions workflow cofigutration file, RuboCop-related files are assigned as `ruby/rubocop*.yml` to the target paths.
However, they are missing the hidden file marker `.`, which fails to trigger RuboCop workflow.
It should be fixed.