### PR TITLE
[ruby-on-rails] Bump Gemfile and Bundler ro 4.0.11

### DIFF
--- a/ruby-on-rails/e-navigator/Dockerfile
+++ b/ruby-on-rails/e-navigator/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:4.0.3
 # Install Packages
 RUN apt-get update && apt-get install -y curl build-essential libpq-dev default-libmysqlclient-dev vim tree
 
-ARG BUNDLER_VERSION=4.0.10
+ARG BUNDLER_VERSION=4.0.11
 
 WORKDIR /tmp
 

--- a/ruby-on-rails/e-navigator/Gemfile
+++ b/ruby-on-rails/e-navigator/Gemfile
@@ -26,7 +26,7 @@ gem 'enum_help'
 gem 'dotenv-rails', '~> 3.2.0'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '~> 1.24.0', require: false
+gem 'bootsnap', '~> 1.24.1', require: false
 
 group :development, :test do
   gem 'debug', platforms: %i[ mri windows ], require: false

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.0)
+    bootsnap (1.24.1)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -157,7 +157,7 @@ GEM
     marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -322,7 +322,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.22)
   benchmark (~> 0.5.0)
-  bootsnap (~> 1.24.0)
+  bootsnap (~> 1.24.1)
   brakeman (~> 8.0.4)
   capybara (~> 3.40.0)
   debug
@@ -367,9 +367,10 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.24.0) sha256=34e6dea61ff4895101aa9c10894ce30186bec73fe2279e0eb52040d8d4cec297
+  bootsnap (1.24.1) sha256=d7faea1dc24aa5b22dacc049c9236b64ebf60b14dd49c615e15d8402375d39ef
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -400,7 +401,7 @@ CHECKSUMS
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   mysql2 (0.5.7) sha256=ba09ede515a0ae8a7192040a1b778c0fb0f025fa5877e9be895cd325fa5e9d7b
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -467,4 +467,4 @@ RUBY VERSION
   ruby 4.0.3
 
 BUNDLED WITH
-  4.0.10
+  4.0.11

--- a/ruby-on-rails/perfect-ruby-on-rails/Dockerfile
+++ b/ruby-on-rails/perfect-ruby-on-rails/Dockerfile
@@ -12,7 +12,7 @@ RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs && \
     ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN npm install -g pnpm@10.33.0
 
-ARG BUNDLER_VERSION=4.0.10
+ARG BUNDLER_VERSION=4.0.11
 
 WORKDIR /tmp
 

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile
@@ -31,7 +31,7 @@ gem 'image_processing', '~> 1.14.0'
 gem 'active_storage_validations', '~> 3.0.3'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '~> 1.24.0', require: false
+gem 'bootsnap', '~> 1.24.1', require: false
 
 # environmental variables
 gem 'dotenv-rails', '~> 3.2.0'

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.0)
+    bootsnap (1.24.1)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -182,7 +182,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -383,7 +383,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations (~> 3.0.3)
   benchmark (~> 0.5.0)
-  bootsnap (~> 1.24.0)
+  bootsnap (~> 1.24.1)
   brakeman (~> 8.0.4)
   capybara (~> 3.40.0)
   cssbundling-rails (~> 1.4.1)
@@ -440,9 +440,10 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.24.0) sha256=34e6dea61ff4895101aa9c10894ce30186bec73fe2279e0eb52040d8d4cec297
+  bootsnap (1.24.1) sha256=d7faea1dc24aa5b22dacc049c9236b64ebf60b14dd49c615e15d8402375d39ef
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -483,7 +484,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   multi_xml (0.8.1) sha256=addba0290bac34e9088bfe73dc4878530297a82a7bbd66cb44dcd0a4b86edf5a
   mysql2 (0.5.7) sha256=ba09ede515a0ae8a7192040a1b778c0fb0f025fa5877e9be895cd325fa5e9d7b

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -561,4 +561,4 @@ RUBY VERSION
   ruby 4.0.3
 
 BUNDLED WITH
-  4.0.10
+  4.0.11

--- a/ruby-on-rails/restful-api/Dockerfile
+++ b/ruby-on-rails/restful-api/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:4.0.3
 # Install Packages
 RUN apt-get update && apt-get install -y curl build-essential libpq-dev vim tree
 
-ARG BUNDLER_VERSION=4.0.10
+ARG BUNDLER_VERSION=4.0.11
 
 WORKDIR /tmp
 

--- a/ruby-on-rails/restful-api/Gemfile
+++ b/ruby-on-rails/restful-api/Gemfile
@@ -16,7 +16,7 @@ gem 'bcrypt', '~> 3.1.22'
 gem 'mysql2', '~> 0.5.7'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '~> 1.24.0', require: false
+gem 'bootsnap', '~> 1.24.1', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/ruby-on-rails/restful-api/Gemfile.lock
+++ b/ruby-on-rails/restful-api/Gemfile.lock
@@ -445,4 +445,4 @@ RUBY VERSION
   ruby 4.0.3
 
 BUNDLED WITH
-  4.0.10
+  4.0.11

--- a/ruby-on-rails/restful-api/Gemfile.lock
+++ b/ruby-on-rails/restful-api/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
-    bootsnap (1.24.0)
+    bootsnap (1.24.1)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -149,7 +149,7 @@ GEM
       net-smtp
     marcel (1.1.0)
     mini_mime (1.1.5)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -302,7 +302,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.14)
   bcrypt (~> 3.1.22)
-  bootsnap (~> 1.24.0)
+  bootsnap (~> 1.24.1)
   brakeman (~> 8.0.4)
   database_cleaner (~> 2.1.0)
   debug
@@ -345,9 +345,10 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  bootsnap (1.24.0) sha256=34e6dea61ff4895101aa9c10894ce30186bec73fe2279e0eb52040d8d4cec297
+  bootsnap (1.24.1) sha256=d7faea1dc24aa5b22dacc049c9236b64ebf60b14dd49c615e15d8402375d39ef
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   case_transform (0.2) sha256=e2ad4418dceeb227cf474cc332cd5004c95c136c04186c1cceaad8ab8de6fe3b
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -382,7 +383,7 @@ CHECKSUMS
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   mysql2 (0.5.7) sha256=ba09ede515a0ae8a7192040a1b778c0fb0f025fa5877e9be895cd325fa5e9d7b
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b


### PR DESCRIPTION
## 1. Overview

This document summarizes the differences between Bundler versions 4.0.10 (released April 8, 2026) and 4.0.11 (released April 30, 2026). The comparison includes 25 commits over 22 days with changes across performance, features, bug fixes, and documentation.

- CHANGELOG
  - [4.0.10](https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md#4010--2026-04-08)
  - [4.0.11](https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md#4011--2026-04-30)
- [Diffs](https://github.com/ruby/rubygems/compare/v4.0.10...bundler-v4.0.11)

## 2. Version Release Details

### 2-1. Version 4.0.10

- **Release Date:** April 8, 2026
- **Key Focus:** Performance optimization, platform improvements, and feature additions

### 2-2. Version 4.0.11

- **Release Date:** April 30, 2026
- **Key Focus:** Checksum locking for Bundler itself, bug fixes for native extensions, and documentation improvements

## 3. Enhancements

### 3-1. Version 4.0.10 Enhancements

1. **Performance Optimization:**
   - Cache package version selection (PR https://github.com/ruby/rubygems/pull/9410)
   - Introduce a fast path for comparing Gem::Version (PR https://github.com/ruby/rubygems/pull/9414)
   - Check happy path first when comparing gem version (PR https://github.com/ruby/rubygems/pull/9417)
2. **Platform Handling:**
   - Ignore warnings with spec different platforms (PR https://github.com/ruby/rubygems/pull/8508)
   - Improve error message when current platform is not in lockfile (PR https://github.com/ruby/rubygems/pull/9439)
3. **Feature Addition:**
   - `default_cli_command` for config: Allows specifying what command Bundler runs when no specific command is provided (PR https://github.com/ruby/rubygems/pull/8886)

### 3-2. Version 4.0.11 Enhancements

1. **Gem Creation Documentation:**
   - Update gem creation guide URL to rubygems.org (PR https://github.com/ruby/rubygems/pull/9500)
2. **Lockfile Checksum Feature:**
   - Lock the checksum of Bundler itself in the lockfile (PR https://github.com/ruby/rubygems/pull/9366)
   - This ensures Bundler integrity is verified during installation

## 4. Bug Fixes

### 4-1. Version 4.0.10 Bug Fixes

1. **Dependency Management:**
   - Restore rb_sys dependency for Rust (PR https://github.com/ruby/rubygems/pull/9416)
   - Addresses critical Rust extension build requirements

### 4-2. Version 4.0.11 Bug Fixes

1. **Native Extensions with Transitive Dependencies:**
   - Fix installing gems with native extensions + transitive dependencies (PR https://github.com/ruby/rubygems/pull/9477)
   - Resolves installation issues where gems with C/Rust extensions and multiple dependency layers failed
2. **Bundler Version Tracking:**
   - Fix the bundler version not being updated in dev/test lockfile (PR https://github.com/ruby/rubygems/pull/9463)
   - Ensures lockfile reflects the correct Bundler version during development
3. **CI/Release Process:**
   - Ensure the release CI doesn't break due to the Bundler checksum feature (PR https://github.com/ruby/rubygems/pull/9436)
   - Addresses CI failures when using the new checksum validation feature:
     - Skip bundler self-checksum for unreleased bundlers (PR https://github.com/ruby/rubygems/pull/9501)
     - Skip bundler self-checksum on ruby-core in test fixtures (PR https://github.com/ruby/rubygems/pull/9506)
     - Replace targeted :ruby_repo skip (PR not specified)

## 5. Code Quality & Maintenance

### 5-1. Version 4.0.11 Improvements

1. **Formatting & Style Fixes:**
   - Fix inconsistent indentation at line 481 in git_spec.rb
   - Fix lockfile DEPENDENCIES section to use 'rubocop' instead of 'parallel'
   - Fix test_execute_allowed_push_host response message to match expected format
   - Fix typo in test description: 'to' -> 'do'
   - Use distinct gemspec filenames in stub_with_version and stub_without_version
   - Fix grammar in gem installer cache comment
2. **Test Improvements:**
   - Various test naming and structure fixes to improve maintainability
3. **Documentation:**
   - Fix formatting for BUNDLE_PREFER_PATCH variable in man page (PR https://github.com/ruby/rubygems/pull/9474)

## 6. Feature Additions by Category

### 6-1. Version 4.0.10 Feature Categories

| Category | Feature | PR |
|----------|---------|-----|
| Performance | Version selection caching | https://github.com/ruby/rubygems/pull/9410 |
| Performance | Fast path for Gem::Version comparison | https://github.com/ruby/rubygems/pull/9414 |
| Performance | Happy path optimization | https://github.com/ruby/rubygems/pull/9417 |
| Platform | Ignore platform-specific spec warnings | https://github.com/ruby/rubygems/pull/8508 |
| Platform | Error message improvement | https://github.com/ruby/rubygems/pull/9439 |
| CLI | default_cli_command config option | https://github.com/ruby/rubygems/pull/8886 |

### 6-2. Version 4.0.11 Feature Categories

| Category | Feature | PR |
|----------|---------|-----|
| Security | Bundler checksum locking | https://github.com/ruby/rubygems/pull/9366 |
| Documentation | Gem creation URL update | https://github.com/ruby/rubygems/pull/9500 |
| Reliability | Native extension + transitive deps | https://github.com/ruby/rubygems/pull/9477 |
| Tracking | Bundler version in lockfile | https://github.com/ruby/rubygems/pull/9463 |
| CI/Testing | Checksum feature CI support | https://github.com/ruby/rubygems/pull/9436, https://github.com/ruby/rubygems/pull/9501, https://github.com/ruby/rubygems/pull/9506 |

## 7. Key Differences Summary

### 7-1. Performance Focus

- **4.0.10:** Heavily focused on runtime performance optimization through caching and fast paths
- **4.0.11:** Focus shifts to stability and correctness over performance

### 7-2. Feature Stability

- **4.0.10:** Introduces new features and optimizations
- **4.0.11:** Stabilizes new checksum feature introduced post-4.0.10, fixes related CI issues

### 7-3. Scope of Changes

- **4.0.10:** 4 main enhancements, 1 bug fix (~5 commits)
- **4.0.11:** 2 enhancements, 3 major bug fix categories, extensive code quality improvements (~20 commits)

### 7-4. Developer Experience

- **4.0.10:** Improves error messages and platform handling for end users
- **4.0.11:** Improves CI reliability and checksum validation for both end users and release process

## 8. Commit Statistics (4.0.10...4.0.11)

- **Total Commits:** 25
- **Commits on Apr 8, 2026:** 2-4 (4.0.10 release preparation)
- **Commits on Apr 30, 2026:** 20+ (4.0.11 development and release)
- **Files Changed:** 67
- **Key Contributors:** hsbt, Edouard-chin, Claude (via Copilot), and others

## 9. Bundler Checksum Feature (4.0.11 Major Addition)

### 9-1. Overview

The new checksum locking feature in 4.0.11 represents the most significant addition between these versions:

- **Purpose:** Verify the integrity of Bundler itself in lockfiles
- **Implementation:** Stores Bundler checksum similar to gem checksums
- **CI Impact:** Required special handling for:
  - Unreleased Bundler versions
  - Test fixtures using ruby-core
  - Development lockfiles

### 9-2. Related Fixes

Multiple commits were needed to stabilize this feature:

- PR https://github.com/ruby/rubygems/pull/9463: Update bundler version in dev/test lockfiles
- PR https://github.com/ruby/rubygems/pull/9436: Graceful handling in release CI
- PR https://github.com/ruby/rubygems/pull/9501: Skip self-checksum for unreleased bundlers
- PR https://github.com/ruby/rubygems/pull/9506: Skip self-checksum on ruby-core fixtures

## 10. Migration Notes from 4.0.10 to 4.0.11

### 10-1. For End Users

1. **Checksum Validation:** Bundler checksums will now be validated
2. **Lockfile Changes:** New `bundler` entry may appear in lockfile DEPENDENCIES section
3. **Performance:** Negligible performance impact; native extension installation more reliable

### 10-2. For CI/Release Systems

1. **Ruby-core:** Skip Bundler self-checksum for ruby-core CI environments
2. **Unreleased Versions:** Configure checksum skipping for pre-release Bundler versions
3. **Lockfile Updates:** Ensure dev/test lockfiles are updated with correct Bundler version

## 11. Technical Improvements Summary

| Aspect | 4.0.10 | 4.0.11 |
|--------|--------|--------|
| **Performance** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
| **Stability** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
| **Features** | ⭐⭐⭐⭐ | ⭐⭐⭐ |
| **Documentation** | ⭐⭐⭐ | ⭐⭐⭐⭐ |
| **Code Quality** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
| **CI/Testing** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ |