### PR TITLE
[python] Migrate to pytest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,4 +41,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Run UnitTest
         working-directory: ./python
-        run: python -m unittest discover ./test
+        run: pytest

--- a/python/README.md
+++ b/python/README.md
@@ -5,3 +5,38 @@
 ## 2. Reference
 
 [独学プログラマー Python言語の基本から仕事のやり方まで](https://bookmeter.com/books/12669037)
+
+## 3. Install Libraries via requirements.txt
+
+```command
+$ pip install -r requirements.txt
+```
+
+## 4. Unit Test
+
+```command
+$ pytest
+============================= test session starts ==============================
+platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
+rootdir: /mnt/c/Users/binlh/Documents/development/tutorials/python
+collected 47 items
+
+test/test_basic.py .....                                                 [ 10%]
+test/test_circle.py .                                                    [ 12%]
+test/test_container.py .....                                             [ 23%]
+test/test_file.py ...                                                    [ 29%]
+test/test_function.py .....                                              [ 40%]
+test/test_hexagon.py .                                                   [ 42%]
+test/test_horse.py .                                                     [ 44%]
+test/test_is_the_same.py ..                                              [ 48%]
+test/test_loop.py .....                                                  [ 59%]
+test/test_modu.py ..                                                     [ 63%]
+test/test_pet.py .                                                       [ 65%]
+test/test_rectangle.py .                                                 [ 68%]
+test/test_rider.py .                                                     [ 70%]
+test/test_square.py ...                                                  [ 76%]
+test/test_strings.py ..........                                          [ 97%]
+test/test_triangle.py .                                                  [100%]
+
+============================== 47 passed in 1.58s ==============================
+```


### PR DESCRIPTION
## 1. Overview

Pytest is superior to Python’s built-in unittest (and its discover capability) primarily due to its minimal boilerplate code, advanced fixture system for dependency management, and highly readable, simple assert statements.  
It offers superior test discovery, robust plugin support, parameterization, and faster execution via parallel testing.

## 2. Benefits

- **Less Verbose (No Classes Required)**: Pytest allows you to write simple functions to test, whereas `unittest `forces you to organize tests inside classes inheriting from `unittest.TestCase`
- **Simple Assertions**: Instead of `self.assertEqual(a, b)`, you just use Python’s native `assert a == b`. Pytest provides detailed inspection of failed assertions, showing you exactly what went wrong without needing manual error messages
- **Powerful Fixtures**: Pytest’s fixture system is far more modular, scalable, and easier to use for `setup/teardown` than unittest's `setUp/tearDown` methods
- **Parameterization**: Pytest makes it simple to run the same test with different input values using `@pytest.mark.parametrize`, reducing code duplication
- **Massive Plugin Ecosystem**: With hundreds of plugins (e.g., `pytest-cov`, `pytest-django`, `pytest-asyncio`), it is highly extensible, while unittest is limited to built-in functionality
- **Better Test Discovery and Selection**: While `discover `works, `pytest `offers more powerful, intuitive filtering to run specific subsets of tests (by name, marker, or directory)
- **Faster Execution**: Pytest supports running tests in parallel, significantly reducing testing time for large projects

## 3. Summary

In summary, pytest is preferred for its "simple, rapid and fun" approach, significantly reducing the maintenance burden of your test suite.