### PR TITLE
[ruby-on-rails] Bump Docker to 29.4.2

### DIFF
--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -2,7 +2,7 @@
 
 - Rails 8.1.2
 - Ruby 4.0.3
-- Docker 29.4.1
+- Docker 29.4.2
 
 ## 2. READMEs
 


### PR DESCRIPTION
## 1. Overview

Docker 29.4.2 (released May 2026) is a security-focused patch updating 29.4.1 to mitigate [CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431) ("Copy Fail").  
It hardens container security by blocking `AF_ALG` sockets and `socketcall(2)` in the default seccomp profile, though this may break 32-bit (i386) programs and SteamCMD.

## 2. Key Differences

- **Security Mitigation**: 29.4.2 includes crucial hardening against a kernel crypto API privilege escalation vulnerability
- **Seccomp Profile Update**: The default seccomp profile now restricts AF_ALG sockets to prevent in-container exploitation
- **Known Issues (29.4.2)**: The security changes can cause issues with older 32-bit applications, specifically affecting SteamCMD and Wine-based workloads
- **Workaround**: The recommendation for affected apps is to avoid using `--security-opt seccomp=unconfined`

## 3. Summary

This patch focuses entirely on security improvements rather than new functionality, following the major architectural shifts (like default containerd store) introduced earlier in the v29 cycle.