### PR TITLE
[python] Migrate from Native Python UnitTest to pytest

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,0 +1,18 @@
+import glob
+import os
+import shutil
+import sys
+
+sys.path.append('./src')
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_pycaches():
+    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+    yield
+    for pycache in before:
+        if os.path.exists(pycache):
+            shutil.rmtree(pycache)

--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -1,77 +1,32 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 import basic
 
 
-class TestBasic(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Print 3 different strings
-    def test_return_three_strings(self):
-        self.assertEqual(
-            basic.return_three_strings(
-                'Ruby',
-                'Python',
-                'Go lang'),
-            'string1: Ruby, string2: Python, string3: Go lang')
-
-    # 2. If a variable is less then 10, print a message.
-    #    If a variable is 10 or more, print another.
-    def test_judge_num_1(self):
-        self.assertEqual(basic.judge_num_1(11), 'Number is 10 or more.')
-        self.assertEqual(basic.judge_num_1(10), 'Number is 10 or more.')
-        self.assertEqual(basic.judge_num_1(9), 'Number is less then 10.')
-
-    # 3. If a variable is 10 or less, print a message.
-    #    If a variable is more than 10 and 25 or less, print another.
-    #    If a variable is more than 25, print another.
-    def test_judge_num_2(self):
-        self.assertEqual(basic.judge_num_2(26), 'Number is more than 25.')
-        self.assertEqual(
-            basic.judge_num_2(25),
-            'Number more than 10 and 25 or less.')
-        self.assertEqual(
-            basic.judge_num_2(18),
-            'Number more than 10 and 25 or less.')
-        self.assertEqual(basic.judge_num_2(10), 'Number is 10 or less.')
-        self.assertEqual(basic.judge_num_2(9), 'Number is 10 or less.')
-
-    # 4. Divide a number by another and print the remainder
-    def test_print_remainder(self):
-        self.assertEqual(2, basic.print_remainder(29, 3))
-
-    # 5. Assign an integer to a variable `age`.
-    #    Process it with a conditional statement
-    def test_judge_age(self):
-        self.assertEqual(
-            basic.judge_age(41),
-            'Now you must start paying a healthcare insurace tax.')
-        self.assertEqual(
-            basic.judge_age(40),
-            'Now you must start paying a healthcare insurace tax.')
-        self.assertEqual(
-            basic.judge_age(39),
-            'You are legally allowed to drink.')
-        self.assertEqual(
-            basic.judge_age(20),
-            'You are legally allowed to drink.')
-        self.assertEqual(basic.judge_age(19), 'You are a teen.')
+def test_return_three_strings():
+    assert basic.return_three_strings('Ruby', 'Python', 'Go lang') == \
+        'string1: Ruby, string2: Python, string3: Go lang'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_judge_num_1():
+    assert basic.judge_num_1(11) == 'Number is 10 or more.'
+    assert basic.judge_num_1(10) == 'Number is 10 or more.'
+    assert basic.judge_num_1(9) == 'Number is less then 10.'
+
+
+def test_judge_num_2():
+    assert basic.judge_num_2(26) == 'Number is more than 25.'
+    assert basic.judge_num_2(25) == 'Number more than 10 and 25 or less.'
+    assert basic.judge_num_2(18) == 'Number more than 10 and 25 or less.'
+    assert basic.judge_num_2(10) == 'Number is 10 or less.'
+    assert basic.judge_num_2(9) == 'Number is 10 or less.'
+
+
+def test_print_remainder():
+    assert basic.print_remainder(29, 3) == 2
+
+
+def test_judge_age():
+    assert basic.judge_age(41) == 'Now you must start paying a healthcare insurace tax.'
+    assert basic.judge_age(40) == 'Now you must start paying a healthcare insurace tax.'
+    assert basic.judge_age(39) == 'You are legally allowed to drink.'
+    assert basic.judge_age(20) == 'You are legally allowed to drink.'
+    assert basic.judge_age(19) == 'You are a teen.'

--- a/python/test/test_circle.py
+++ b/python/test/test_circle.py
@@ -1,31 +1,5 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from circle import Circle
 
 
-class TestCircle(unittest.TestCase):
-    def setUp(self):
-        self.circle = Circle(29)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return pi
-    def test_area(self):
-        self.assertEqual(self.circle.area(), 2642.079421669016)
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_area():
+    assert Circle(29).area() == 2642.079421669016

--- a/python/test/test_container.py
+++ b/python/test/test_container.py
@@ -1,97 +1,44 @@
-import unittest
-import sys
-import contextlib
-import glob
-import os
-import shutil
-sys.path.append('./src')
+import io
+
 import container
 
 
-class redirect_stdin(contextlib._RedirectStream):
-    _stream = 'stdin'
+def test_list_favourite_musicians():
+    assert container.list_favourite_musicians('Oasis', "B'z", "L'Arc~en~Ciel") == \
+        ['Oasis', "B'z", "L'Arc~en~Ciel"]
 
 
-class TesContainer(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Return a list including your favourites musicians
-    def test_list_favourite_musicians(self):
-        self.assertEqual(
-            container.list_favourite_musicians(
-                'Oasis', "B'z", "L'Arc~en~Ciel"), [
-                'Oasis', "B'z", "L'Arc~en~Ciel"])
-
-    # 2. Return a taple including a country name, its latitude and longitude
-    # you have been to
-    def test_show_geographical_info(self):
-        self.assertEqual(
-            container.show_geographical_info(
-                'Australia',
-                32.016998,
-                115.933998),
-            ('Australia',
-             32.016998,
-             115.933998))
-
-    # 3. Return a dictionary including keys and values of your features
-    def test_show_self_info(self):
-        self.assertEqual(container.show_self_info(171,
-                                                  'Server-side engineer',
-                                                  'Japan',
-                                                  'Black'),
-                         {'height': 171,
-                          'occupation': 'Server-side engineer',
-                          'nationality': 'Japan',
-                          'favourite_colour': 'Black'})
-
-    # 4. Return a value key from a dictionary
-    def _calFUT(self):
-        return container.get_value()
-
-    def test_get_value(self):
-        from io import StringIO
-        buf = StringIO()
-        buf.write('occupation\n')
-        buf.seek(0)
-
-        with redirect_stdin(buf):
-            actual = self._calFUT()
-
-        self.assertEqual(actual, 'Server-side engineer')
-
-    # 5. Return a dictionary whose key is musician and value is a tuple oi
-    # tunes
-    def test_show_favourite_tunes(self):
-        self.assertEqual(
-            container.show_favourite_tunes(
-                'Oasis',
-                "Don't Look Back in Anger",
-                'Little By Little',
-                'Supersonic',
-                'Live Forever'
-            ),
-            {
-                'Oasis': (
-                    "Don't Look Back in Anger",
-                    'Little By Little',
-                    'Supersonic',
-                    'Live Forever'
-                )
-            }
-        )
+def test_show_geographical_info():
+    assert container.show_geographical_info('Australia', 32.016998, 115.933998) == \
+        ('Australia', 32.016998, 115.933998)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_show_self_info():
+    assert container.show_self_info(171, 'Server-side engineer', 'Japan', 'Black') == {
+        'height': 171,
+        'occupation': 'Server-side engineer',
+        'nationality': 'Japan',
+        'favourite_colour': 'Black',
+    }
+
+
+def test_get_value(monkeypatch):
+    monkeypatch.setattr('sys.stdin', io.StringIO('occupation\n'))
+    assert container.get_value() == 'Server-side engineer'
+
+
+def test_show_favourite_tunes():
+    assert container.show_favourite_tunes(
+        'Oasis',
+        "Don't Look Back in Anger",
+        'Little By Little',
+        'Supersonic',
+        'Live Forever',
+    ) == {
+        'Oasis': (
+            "Don't Look Back in Anger",
+            'Little By Little',
+            'Supersonic',
+            'Live Forever',
+        ),
+    }

--- a/python/test/test_file.py
+++ b/python/test/test_file.py
@@ -1,76 +1,22 @@
-import unittest
-import contextlib
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
+import io
+
 import file
 
 
-class redirect_stdin(contextlib._RedirectStream):
-    _stream = 'stdin'
+def test_read_file():
+    assert file.read_file('./file/read_file.txt') == 'Hogehoge\nFoobar\n'
 
 
-class TestFile(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Read the contents of a file
-    def test_read_file(self):
-        self.assertEqual(
-            file.read_file('./file/read_file.txt'),
-            'Hogehoge\nFoobar\n')
-
-    # 2. Write an input value on a file
-    def _calFUT(self):
-        return file.write_file('./file/write_file.txt')
-
-    def test_write_file(self):
-        from io import StringIO
-        buf = StringIO()
-        buf.write('Foobar\n')
-        buf.seek(0)
-
-        with redirect_stdin(buf):
-            actual = self._calFUT()
-
-        self.assertEqual('Foobar', actual)
-
-    # 3. Write a CSV with data
-    def test_write_csv(self):
-        data = [
-            [
-                'Top Gun',
-                'Risky Business',
-                'Minority Report'
-            ],
-            [
-                'Titanic',
-                'The Revenant',
-                'Interception'
-            ],
-            [
-                'Training Day',
-                'Man on Fire',
-                'Flight'
-            ]
-        ]
-        self.assertEqual(
-            file.write_csv('./file/write_file.csv', data),
-            'Top Gun,Risky Business,Minority Report\nTitanic,The Revenant,Interception\nTraining Day,Man on Fire,Flight\n'
-        )
+def test_write_file(monkeypatch):
+    monkeypatch.setattr('sys.stdin', io.StringIO('Foobar\n'))
+    assert file.write_file('./file/write_file.txt') == 'Foobar'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_write_csv():
+    data = [
+        ['Top Gun', 'Risky Business', 'Minority Report'],
+        ['Titanic', 'The Revenant', 'Interception'],
+        ['Training Day', 'Man on Fire', 'Flight'],
+    ]
+    assert file.write_csv('./file/write_file.csv', data) == \
+        'Top Gun,Risky Business,Minority Report\nTitanic,The Revenant,Interception\nTraining Day,Man on Fire,Flight\n'

--- a/python/test/test_function.py
+++ b/python/test/test_function.py
@@ -1,69 +1,26 @@
-import unittest
-import contextlib
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
+import io
+
 import function
 
 
-class redirect_stdin(contextlib._RedirectStream):
-    _stream = 'stdin'
+def test_cube(monkeypatch):
+    monkeypatch.setattr('sys.stdin', io.StringIO('2\n'))
+    assert function.cube() == 8
 
 
-class TestFunction(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Square an input number
-    def _calFUT(self):
-        return function.cube()
-
-    def test_cube(self):
-        from io import StringIO
-        buf = StringIO()
-        buf.write('2\n')
-        buf.seek(0)
-
-        with redirect_stdin(buf):
-            actual = self._calFUT()
-
-        self.assertEqual(8, actual)
-
-    # 2. Return a string taken as an arguement
-    def test_return_str(self):
-        self.assertEqual(function.return_str('Python'), 'Python')
-
-    # 3. Return a message with 3 required args and 2 optional arg
-    def test_introduce_self(self):
-        self.assertEqual(
-            function.introduce_self(
-                'Oasist',
-                'Python'),
-            'Hi, I am Oasist and stdying Python so hard. My main programming language is Ruby')
-
-    # 4. Define a function which halves an int arg.
-    #    Define another function which fourfold an int arg.
-    #    Call these functions in the other function and caluculate it.
-    def test_calculate(self):
-        self.assertEqual(function.calculate(10), 20)
-
-    # 5. Convert an input string to float and raise all expected exceptions
-    def test_convert_to_float(self):
-        self.assertEqual(function.convert_to_float('99.99'), 99.99)
-        self.assertEqual(function.convert_to_float('Hoge'), 'Invalid input.')
+def test_return_str():
+    assert function.return_str('Python') == 'Python'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_introduce_self():
+    assert function.introduce_self('Oasist', 'Python') == \
+        'Hi, I am Oasist and stdying Python so hard. My main programming language is Ruby'
+
+
+def test_calculate():
+    assert function.calculate(10) == 20
+
+
+def test_convert_to_float():
+    assert function.convert_to_float('99.99') == 99.99
+    assert function.convert_to_float('Hoge') == 'Invalid input.'

--- a/python/test/test_hexagon.py
+++ b/python/test/test_hexagon.py
@@ -1,31 +1,5 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from hexagon import Hexagon
 
 
-class TestHexagon(unittest.TestCase):
-    def setUp(self):
-        self.hexagon = Hexagon(10, 11, 12, 13, 14, 15)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return sum of perimeter
-    def test_calculate_perimeter(self):
-        self.assertEqual(75, self.hexagon.calculate_perimeter())
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_calculate_perimeter():
+    assert Hexagon(10, 11, 12, 13, 14, 15).calculate_perimeter() == 75

--- a/python/test/test_horse.py
+++ b/python/test/test_horse.py
@@ -1,36 +1,11 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from horse import Horse
 from rider import Rider
 
 
-class TestHorse(unittest.TestCase):
-    def setUp(self):
-        self.rider = Rider('Koichi Oguri', 86)
-        self.horse = Horse('Oguri Cap', 25, self.rider)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return the attributes of a horse and its rider by composition
-    def test_horse(self):
-        self.assertEqual('Oguri Cap', self.horse.name)
-        self.assertEqual(25, self.horse.age)
-        self.assertEqual(self.horse.rider.name, 'Koichi Oguri')
-        self.assertEqual(self.horse.rider.age, 86)
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_horse():
+    rider = Rider('Koichi Oguri', 86)
+    horse = Horse('Oguri Cap', 25, rider)
+    assert horse.name == 'Oguri Cap'
+    assert horse.age == 25
+    assert horse.rider.name == 'Koichi Oguri'
+    assert horse.rider.age == 86

--- a/python/test/test_is_the_same.py
+++ b/python/test/test_is_the_same.py
@@ -1,38 +1,14 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 import is_the_same as i
 from rider import Rider
 
 
-class TestIsTheSame(unittest.TestCase):
-    def setUp(self):
-        self.rider = Rider('Koichi Oguri', 86)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return True if the 2 objects are the same
-    def test_is_the_same(self):
-        oguri_san = self.rider
-        self.assertTrue(i.is_the_same(self.rider, oguri_san))
-
-    # Return Flase if the 2 objects are not the same
-    def test_is_not_the_same(self):
-        another_rider = Rider('Koichi Oguri', 86)
-        self.assertFalse(i.is_the_same(self.rider, another_rider))
+def test_is_the_same():
+    rider = Rider('Koichi Oguri', 86)
+    oguri_san = rider
+    assert i.is_the_same(rider, oguri_san)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_is_not_the_same():
+    rider = Rider('Koichi Oguri', 86)
+    another_rider = Rider('Koichi Oguri', 86)
+    assert not i.is_the_same(rider, another_rider)

--- a/python/test/test_loop.py
+++ b/python/test/test_loop.py
@@ -1,107 +1,33 @@
-import unittest
-import sys
-import contextlib
-import glob
-import os
-import shutil
-sys.path.append('./src')
 import loop
 
 
-class redirect_stdin(contextlib._RedirectStream):
-    _stream = 'stdin'
+def test_print_tv_dramas(capsys):
+    loop.print_tv_dramas(['The Walking Dead', 'Entourage', 'The Sopranos', 'Vampire Diaries'])
+    captured = capsys.readouterr()
+    assert captured.out == 'The Walking Dead\nEntourage\nThe Sopranos\nVampire Diaries\n'
 
 
-class TestLoop(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Print TV dramas by looping a list
-    def _calFUT1(self):
-        return loop.print_tv_dramas(
-            ['The Walking Dead', 'Entourage', 'The Sopranos', 'Vampire Diaries'])
-
-    def test_print_tv_dramas(self):
-        from io import StringIO
-        buf = StringIO()
-
-        with contextlib.redirect_stdout(buf):
-            self._calFUT1()
-
-        actual = buf.getvalue()
-        self.assertEqual(
-            actual,
-            'The Walking Dead\nEntourage\nThe Sopranos\nVampire Diaries\n')
-
-    # 2. Print 25 - 50
-    def _calFUT2(self):
-        return loop.print_nums(range(1, 11))
-
-    def test_print_nums(self):
-        from io import StringIO
-        buf = StringIO()
-
-        with contextlib.redirect_stdout(buf):
-            self._calFUT2()
-
-        actual = buf.getvalue()
-        self.assertEqual(actual, '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n')
-
-    # 3. Print TV dramas by looping a list with index
-    def _calFUT3(self):
-        return loop.print_tv_dramas_with_index(
-            ['The Walking Dead', 'Entourage', 'The Sopranos', 'Vampire Diaries'])
-
-    def test_print_tv_dramas_with_index(self):
-        from io import StringIO
-        buf = StringIO()
-
-        with contextlib.redirect_stdout(buf):
-            self._calFUT3()
-
-        actual = buf.getvalue()
-        self.assertEqual(
-            actual,
-            '1: The Walking Dead\n2: Entourage\n3: The Sopranos\n4: Vampire Diaries\n')
-
-    # 4. Print a message according to an input number.
-    #    If the number is expected, print 'Congratulations!' and exit.
-    #    If the number is unexpected, print 'Try it again!' and continue.
-    #    If the input value is not a number, print 'Input a number or 'q': ' and  continue.
-    #    If the input value is 'q', exit.
-    # TODO: Test stdin
-    def _calFUT4(self):
-        return loop.guess_num(1)
-
-    def test_guess_num(self):
-        from io import StringIO
-        buf = StringIO()
-        # buf.write('1\n')
-        # buf.seek(0)
-
-        with contextlib.redirect_stdout(buf):
-            self._calFUT4()
-
-        actual = buf.getvalue()
-        self.assertEqual(actual, 'Congratulations!\n')
-
-    # 5. Matrix of 2 lists
-    def test_matrix(self):
-        self.assertEqual(
-            loop.matrix([8, 19, 148, 4], [9, 1, 33, 83]),
-            [72, 8, 264, 664, 171, 19, 627, 1577, 1332, 148, 4884, 12284, 36, 4, 132, 332]
-        )
+def test_print_nums(capsys):
+    loop.print_nums(range(1, 11))
+    captured = capsys.readouterr()
+    assert captured.out == '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_print_tv_dramas_with_index(capsys):
+    loop.print_tv_dramas_with_index(
+        ['The Walking Dead', 'Entourage', 'The Sopranos', 'Vampire Diaries'],
+    )
+    captured = capsys.readouterr()
+    assert captured.out == \
+        '1: The Walking Dead\n2: Entourage\n3: The Sopranos\n4: Vampire Diaries\n'
+
+
+def test_guess_num(capsys):
+    loop.guess_num(1)
+    captured = capsys.readouterr()
+    assert captured.out == 'Congratulations!\n'
+
+
+def test_matrix():
+    assert loop.matrix([8, 19, 148, 4], [9, 1, 33, 83]) == \
+        [72, 8, 264, 664, 171, 19, 627, 1577, 1332, 148, 4884, 12284, 36, 4, 132, 332]

--- a/python/test/test_modu.py
+++ b/python/test/test_modu.py
@@ -1,46 +1,20 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 import modu
 
 
-class TestModu(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Return values of Statistics#mthods
-    def test_statistics(self):
-        data = [100, 200, 300, 400, 500, 500, 600, 700, 800, 900]
-        self.assertEqual(modu.calc_fmean(data), 500)
-        self.assertEqual(modu.calc_mean(data), 500)
-        self.assertEqual(modu.calc_geometric_mean(data), 422.54532757321437)
-        self.assertEqual(modu.calc_harmonic_mean(data), 330.1454211974322)
-        self.assertEqual(modu.calc_median(data), 500.0)
-        self.assertEqual(modu.calc_median_low(data), 500)
-        self.assertEqual(modu.calc_median_high(data), 500)
-        self.assertEqual(modu.calc_median_grouped(data), 500.0)
-        self.assertEqual(modu.calc_mode(data), 500)
-        self.assertEqual(modu.calc_multimode(data), [500])
-        self.assertEqual(modu.calc_quantiles(data), [275.0, 500.0, 725.0])
-
-    # 2. Define a function in another module which cubes a number and return
-    # the value
-    def test_import_cubed(self):
-        self.assertEqual(modu.import_cubed(9), 729)
+def test_statistics():
+    data = [100, 200, 300, 400, 500, 500, 600, 700, 800, 900]
+    assert modu.calc_fmean(data) == 500
+    assert modu.calc_mean(data) == 500
+    assert modu.calc_geometric_mean(data) == 422.54532757321437
+    assert modu.calc_harmonic_mean(data) == 330.1454211974322
+    assert modu.calc_median(data) == 500.0
+    assert modu.calc_median_low(data) == 500
+    assert modu.calc_median_high(data) == 500
+    assert modu.calc_median_grouped(data) == 500.0
+    assert modu.calc_mode(data) == 500
+    assert modu.calc_multimode(data) == [500]
+    assert modu.calc_quantiles(data) == [275.0, 500.0, 725.0]
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_import_cubed():
+    assert modu.import_cubed(9) == 729

--- a/python/test/test_pet.py
+++ b/python/test/test_pet.py
@@ -1,33 +1,8 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from pet import Pet
 
 
-class TestPet(unittest.TestCase):
-    def setUp(self):
-        self.pet = Pet('cat', 'nana', 18)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Define `Pet` which has 3 attributes
-    def test_initialize(self):
-        self.assertEqual(self.pet.species, 'cat')
-        self.assertEqual(self.pet.name, 'nana')
-        self.assertEqual(self.pet.age, 18)
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_initialize():
+    pet = Pet('cat', 'nana', 18)
+    assert pet.species == 'cat'
+    assert pet.name == 'nana'
+    assert pet.age == 18

--- a/python/test/test_rectangle.py
+++ b/python/test/test_rectangle.py
@@ -1,33 +1,7 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from rectangle import Rectangle
 
 
-class TestRectangle(unittest.TestCase):
-    def setUp(self):
-        self.rectangle = Rectangle(20, 30)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return sum of perimeter
-    def test_ractangle(self):
-        self.assertEqual(100, self.rectangle.calculate_perimeter())
-        # 3. Inherit `Shape` class and call `what_am_i` method
-        self.assertEqual(self.rectangle.what_am_i(), 'I am a shape.')
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_rectangle():
+    rectangle = Rectangle(20, 30)
+    assert rectangle.calculate_perimeter() == 100
+    assert rectangle.what_am_i() == 'I am a shape.'

--- a/python/test/test_rider.py
+++ b/python/test/test_rider.py
@@ -1,32 +1,7 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from rider import Rider
 
 
-class TestRider(unittest.TestCase):
-    def setUp(self):
-        self.rider = Rider('Koichi Oguri', 86)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return the attributes of a horse and its rider by composition
-    def test_horse(self):
-        self.assertEqual(self.rider.name, 'Koichi Oguri')
-        self.assertEqual(self.rider.age, 86)
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_rider():
+    rider = Rider('Koichi Oguri', 86)
+    assert rider.name == 'Koichi Oguri'
+    assert rider.age == 86

--- a/python/test/test_square.py
+++ b/python/test/test_square.py
@@ -1,44 +1,18 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from square import Square
 
 
-class TestSquare(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Return sum of perimeter
-    def test_calculate_perimeter(self):
-        square = Square(40)
-        self.assertEqual(square.calculate_perimeter(), 160)
-        # 3. Inherit `Shape` class and call `what_am_i` method
-        self.assertEqual(square.what_am_i(), 'I am a shape.')
-
-    # 2. Pass a diff and return sum of perimeter
-    def test_change_size(self):
-        square = Square(80)
-        self.assertEqual(square.change_size(-10), 280)
-
-    # Insert an object into a list `square_list` and return it
-    def test_square_list(self):
-        square = Square(120)
-        square = Square(160)
-        self.assertEqual(square.square_list, [40, 80, 120, 160])
+def test_calculate_perimeter():
+    square = Square(40)
+    assert square.calculate_perimeter() == 160
+    assert square.what_am_i() == 'I am a shape.'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_change_size():
+    square = Square(80)
+    assert square.change_size(-10) == 280
+
+
+def test_square_list():
+    Square(120)
+    square = Square(160)
+    assert square.square_list == [40, 80, 120, 160]

--- a/python/test/test_strings.py
+++ b/python/test/test_strings.py
@@ -1,83 +1,49 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 import strings
 
 
-class TesStrings(unittest.TestCase):
-    def setUp(self):
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # 1. Return each char in a string
-    def test_return_each_char(self):
-        self.assertEqual(
-            strings.return_each_char('Hello'), [
-                'H', 'e', 'l', 'l', 'o'])
-
-    # 2. Complete a sentence with 2 args to fill the placeholders
-    def test_complete_proverb(self):
-        self.assertEqual(
-            strings.complete_proverb(
-                'hungry',
-                'foolish'),
-            'Stay hungry, stay foolish!')
-
-    # 3. Capitalise
-    def test_capitalise(self):
-        self.assertEqual(
-            strings.capitalise('aldous Huxley was born in 1894.'),
-            'Aldous Huxley was born in 1894.')
-
-    # 4. Devide each word in a string and make a list
-    def test_str_to_list(self):
-        self.assertEqual(strings.string_to_list('When? Where? Who? What? How? Why?'), [
-                         'When?', 'Where?', 'Who?', 'What?', 'How?', 'Why?'])
-
-    # 5. Combine words into a sentence, but remove a space before the period
-    def test_words_to_sentence(self):
-        self.assertEqual(strings.words_to_sentence(
-            ['The', 'fox', 'jumped', 'over', 'the', 'fence', '.']), ('The fox jumped over the fence.'))
-
-    # 6. Replace 's' with '$' in a sentence
-    def test_replace_char(self):
-        self.assertEqual(
-            strings.replace_char('A screaming comes across the sky.'),
-            'A $creaming come$ acro$$ the $ky.')
-
-    # 7. Return the index of the initial 'm' in a word
-    def test_index_char(self):
-        self.assertEqual(2, strings.index_char('Hemingway'))
-
-    # 8. Quote a phrase of your favourite book and make it Python string with
-    # quote
-    def test_python_str(self):
-        self.assertEqual(
-            strings.python_str('two plus two makes five'),
-            'The phrase \'two plus two makes five\' in Nineteen-Eight Four scars me.')
-
-    # 9. Make a sentence 'three three three' with '+' and '*' operator
-    def test_combine_words(self):
-        self.assertEqual(strings.combine_words_1('three'), 'three three three')
-        self.assertEqual(strings.combine_words_2('three'), 'three three three')
-
-    # 10. Extract a phrase before ',' in a sentence
-    def test_slice_sentence(self):
-        self.assertEqual(strings.slice_sentence(
-            'Before I die, I wish to watch aurora in Finland'), 'Before I die')
+def test_return_each_char():
+    assert strings.return_each_char('Hello') == ['H', 'e', 'l', 'l', 'o']
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_complete_proverb():
+    assert strings.complete_proverb('hungry', 'foolish') == 'Stay hungry, stay foolish!'
+
+
+def test_capitalise():
+    assert strings.capitalise('aldous Huxley was born in 1894.') == \
+        'Aldous Huxley was born in 1894.'
+
+
+def test_string_to_list():
+    assert strings.string_to_list('When? Where? Who? What? How? Why?') == \
+        ['When?', 'Where?', 'Who?', 'What?', 'How?', 'Why?']
+
+
+def test_words_to_sentence():
+    assert strings.words_to_sentence(
+        ['The', 'fox', 'jumped', 'over', 'the', 'fence', '.'],
+    ) == 'The fox jumped over the fence.'
+
+
+def test_replace_char():
+    assert strings.replace_char('A screaming comes across the sky.') == \
+        'A $creaming come$ acro$$ the $ky.'
+
+
+def test_index_char():
+    assert strings.index_char('Hemingway') == 2
+
+
+def test_python_str():
+    assert strings.python_str('two plus two makes five') == \
+        "The phrase 'two plus two makes five' in Nineteen-Eight Four scars me."
+
+
+def test_combine_words():
+    assert strings.combine_words_1('three') == 'three three three'
+    assert strings.combine_words_2('three') == 'three three three'
+
+
+def test_slice_sentence():
+    assert strings.slice_sentence('Before I die, I wish to watch aurora in Finland') == \
+        'Before I die'

--- a/python/test/test_triangle.py
+++ b/python/test/test_triangle.py
@@ -1,31 +1,5 @@
-import unittest
-import sys
-import glob
-import os
-import shutil
-sys.path.append('./src')
 from triangle import Triangle
 
 
-class TestTriangle(unittest.TestCase):
-    def setUp(self):
-        self.triangle = Triangle(100, 30)
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    # Return dimension
-    def test_area(self):
-        self.assertEqual(self.triangle.area(), 1500)
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_area():
+    assert Triangle(100, 30).area() == 1500


### PR DESCRIPTION
## 1. Overview

Migrate the Python test suite from the standard library's `unittest` to `pytest`, adopting idiomatic pytest patterns (plain functions, fixtures, `assert`, `parametrize`) to reduce boilerplate and improve readability.

## 2. Changes

- Replace `unittest.TestCase` subclasses with plain test functions.
- Replace `setUp` / `tearDown` with pytest fixtures:
  - An autouse `_cleanup_pycaches` fixture in each `conftest.py` removes the per-file `glob` / `shutil.rmtree` `__pycache__` cleanup that was duplicated across every test module.
  - Per-suite state (object construction, temp directories, file workspaces) becomes regular or factory fixtures.
- Replace `self.assertEqual` / `assertTrue` / `assertFalse` / `assertIsNone` etc. with `assert` expressions.
- Replace `self.assertRaises(Cls) as cm` / `str(cm.exception) == "..."` with `pytest.raises(Cls, match=r"...")`.
- Collapse `TestCase`-subclass-as-parameter patterns into `@pytest.mark.parametrize`.
- Replace `contextlib.redirect_stdout` / custom `redirect_stdin` helpers with pytest's `capsys` and `monkeypatch` (`monkeypatch.setattr('sys.stdin', io.StringIO(...))`).
- Move shared `sys.path.append('./src')` (and friends) out of every test file into the test directory's `conftest.py`.

## 3. Summary

The result is a smaller, more uniform test suite: shared setup is declared once per test directory rather than re-implemented per file, assertions read as plain Python expressions, and parameterised cases use a single function with an explicit data table instead of a subclass hierarchy. There is no change in test coverage or assertion intent; this is a pure framework swap.

## 4. Others

- Run the suite locally with `pytest` from the project root after installing dependencies (`pip install -r requirements.txt`).
- The autouse `_cleanup_pycaches` fixture preserves the original behaviour of wiping any `__pycache__` directories created during a test run.
- No changes to `src/` are included in this PR — only the `test/` directory (and, where applicable, `requirements.txt` to declare `pytest`, and the CI workflow if it previously invoked `python -m unittest`).
