### PR TITLE
[ruby-on-rails] Bump RuboCop Rails Dependency from 2.35.3 to 2.35.4

### DIFF
--- a/ruby-on-rails/e-navigator/Gemfile
+++ b/ruby-on-rails/e-navigator/Gemfile
@@ -54,7 +54,7 @@ group :development do
   gem 'rubocop-factory_bot', '~> 2.28.0', require: false
   gem 'rubocop-minitest', '~> 0.39.0', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.3', require: false
+  gem 'rubocop-rails', '~> 2.35.4', require: false
   # Typechecking
   gem 'rbs-inline', '~> 0.14.0', require: false
   gem 'rbs_rails', '~> 0.13.1', require: false

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -393,7 +393,7 @@ DEPENDENCIES
   rubocop-factory_bot (~> 2.28.0)
   rubocop-minitest (~> 0.39.0)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.3)
+  rubocop-rails (~> 2.35.4)
   selenium-webdriver (~> 4.44.0)
   steep (~> 2.0.0)
   turbo-rails (~> 2.0.16)

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile
@@ -102,7 +102,7 @@ group :development do
   gem 'rubocop-factory_bot', '~> 2.28.0', require: false
   gem 'rubocop-minitest', '~> 0.39.0', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.3', require: false
+  gem 'rubocop-rails', '~> 2.35.4', require: false
   # Typechecking
   gem 'rbs-inline', '~> 0.14.0', require: false
   gem 'rbs_rails', '~> 0.13.1', require: false

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -470,7 +470,7 @@ DEPENDENCIES
   rubocop-factory_bot (~> 2.28.0)
   rubocop-minitest (~> 0.39.0)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.3)
+  rubocop-rails (~> 2.35.4)
   selenium-webdriver (~> 4.44.0)
   steep (~> 2.0.0)
   turbo-rails (~> 2.0.16)

--- a/ruby-on-rails/restful-api/Gemfile
+++ b/ruby-on-rails/restful-api/Gemfile
@@ -63,7 +63,7 @@ group :development do
   gem 'rubocop', '~> 1.86.2', require: false
   gem 'rubocop-factory_bot', '~> 2.28.0', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.3', require: false
+  gem 'rubocop-rails', '~> 2.35.4', require: false
   gem 'rubocop-rspec', '~> 3.9.0', require: false
   gem 'rubocop-rspec_rails', '~> 2.32.0', require: false
   # Typechecking

--- a/ruby-on-rails/restful-api/Gemfile.lock
+++ b/ruby-on-rails/restful-api/Gemfile.lock
@@ -369,7 +369,7 @@ DEPENDENCIES
   rubocop (~> 1.86.2)
   rubocop-factory_bot (~> 2.28.0)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.3)
+  rubocop-rails (~> 2.35.4)
   rubocop-rspec (~> 3.9.0)
   rubocop-rspec_rails (~> 2.32.0)
   shoulda-matchers (~> 7.0.1)


### PR DESCRIPTION
- Follow up https://github.com/hayat01sh1da/tutorials/pull/301