### PR TITLE
[ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
-    rubyzip (3.3.1)
+    rubyzip (3.4.0)
     securerandom (0.4.1)
     selenium-webdriver (4.44.0)
       base64 (~> 0.2)
@@ -508,7 +508,7 @@ CHECKSUMS
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  rubyzip (3.3.1) sha256=2ed92112c7c43ba2b2527f35e6d99d9c2c99270b640aad5227516436481b1e4e
+  rubyzip (3.4.0) sha256=6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
   steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -369,7 +369,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.3.1)
+    rubyzip (3.4.0)
     securerandom (0.4.1)
     selenium-webdriver (4.44.0)
       base64 (~> 0.2)
@@ -606,7 +606,7 @@ CHECKSUMS
   rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
-  rubyzip (3.3.1) sha256=2ed92112c7c43ba2b2527f35e6d99d9c2c99270b640aad5227516436481b1e4e
+  rubyzip (3.4.0) sha256=6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a


### PR DESCRIPTION
\## 1. Overview

This PR (tutorials #314) is a routine, dependabot-style Gem maintenance update across the Rails sample projects.  
It bumps a **single gem** (`rubyzip`) to its latest minor release, with changes limited to **two `Gemfile.lock` files**.  
No runtime constraints in any `Gemfile` change and there is no Bundler, Ruby, or Rails version change — making it a low-risk maintenance update.

## 2. Key Changes

**Gems updated:**

| Gem | Version Change | Notable Details |
|-----|---|---|
| **rubyzip** | 3.3.1 → 3.4.0 | Minor release adding a top-level `lib/rubyzip.rb` entry point so the gem can be required as `rubyzip` (streamlines Gemfile/`require` integration). Carries forward the breaking-API changes already established across the 3.x series — no new breaking changes versus 3.3.1, so it is backward-compatible for projects already on 3.x. Lockfile `GEM` resolution and the `CHECKSUMS` (SHA-256) entries were refreshed accordingly. |

**Files modified:**

- `ruby-on-rails/e-navigator/Gemfile.lock`
- `ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock`

Both files receive the identical `rubyzip 3.3.1 → 3.4.0` bump, each with its corresponding SHA-256 checksum updated.

## 3. Summary

A backward-compatible minor-level lockfile refresh of a single gem (`rubyzip 3.3.1 → 3.4.0`) applied to two Rails sample projects.  
The only functional change in the release is a new top-level require entry point; no behavioural, security, or breaking changes versus 3.3.1, and no `Gemfile` constraint, Bundler, Ruby, or Rails version changes.

## 4. References

- [rubyzip](https://rubygems.org/gems/rubyzip)
  - [GitHub repository](https://github.com/rubyzip/rubyzip)
- [rubyzip v3.4.0 release](https://github.com/rubyzip/rubyzip/releases/tag/v3.4.0)