### PR TITLE
[ruby-on-rails] Update Gem Dependencies

### DIFF
--- a/ruby-on-rails/e-navigator/Gemfile
+++ b/ruby-on-rails/e-navigator/Gemfile
@@ -54,7 +54,7 @@ group :development do
   gem 'rubocop-factory_bot', '~> 2.28.0', require: false
   gem 'rubocop-minitest', '~> 0.39.0', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.4', require: false
+  gem 'rubocop-rails', '~> 2.35.5', require: false
   # Typechecking
   gem 'rbs-inline', '~> 0.14.0', require: false
   gem 'rbs_rails', '~> 0.13.1', require: false

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -300,7 +300,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.4)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -393,7 +393,7 @@ DEPENDENCIES
   rubocop-factory_bot (~> 2.28.0)
   rubocop-minitest (~> 0.39.0)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.4)
+  rubocop-rails (~> 2.35.5)
   selenium-webdriver (~> 4.45.0)
   steep (~> 2.0.0)
   turbo-rails (~> 2.0.16)
@@ -471,7 +471,7 @@ CHECKSUMS
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
@@ -506,7 +506,7 @@ CHECKSUMS
   rubocop-factory_bot (2.28.0) sha256=4b17fc02124444173317e131759d195b0d762844a71a29fe8139c1105d92f0cb
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
+  rubocop-rails (2.35.5) sha256=f00b3c936002ba8e9ac62e8607c54bb24cda44b36e41b9c7e4f3872e1b0f3fe3
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.4.0) sha256=6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile
@@ -102,7 +102,7 @@ group :development do
   gem 'rubocop-factory_bot', '~> 2.28.0', require: false
   gem 'rubocop-minitest', '~> 0.39.0', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.4', require: false
+  gem 'rubocop-rails', '~> 2.35.5', require: false
   # Typechecking
   gem 'rbs-inline', '~> 0.14.0', require: false
   gem 'rbs_rails', '~> 0.13.1', require: false

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -83,8 +83,8 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    anonymous_loader (0.1.1)
-      version_gem (~> 1.1, >= 1.1.12)
+    anonymous_loader (0.1.2)
+      version_gem (~> 1.1, >= 1.1.13)
     ast (2.4.3)
     auth-sanitizer (0.2.2)
       version_gem (~> 1.1, >= 1.1.10)
@@ -241,7 +241,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -358,7 +358,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.4)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -409,7 +409,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.12)
+    version_gem (1.1.13)
     web-console (4.3.0)
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
@@ -466,7 +466,7 @@ DEPENDENCIES
   rubocop-factory_bot (~> 2.28.0)
   rubocop-minitest (~> 0.39.0)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.4)
+  rubocop-rails (~> 2.35.5)
   selenium-webdriver (~> 4.45.0)
   steep (~> 2.0.0)
   turbo-rails (~> 2.0.16)
@@ -488,7 +488,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  anonymous_loader (0.1.1) sha256=b765191e2eadd6e9da52e4eb41ab44f83241fa013fadddb7a8c1374f71157662
+  anonymous_loader (0.1.2) sha256=8ccf77c3f0812fb93d47956fdd6f30344a3835864e3cb1431ca597905985efc2
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   auth-sanitizer (0.2.2) sha256=300112debb67fe5e7a4f67a697790cea09744970e816745afb1f4235d6f27bae
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -562,7 +562,7 @@ CHECKSUMS
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
@@ -599,7 +599,7 @@ CHECKSUMS
   rubocop-factory_bot (2.28.0) sha256=4b17fc02124444173317e131759d195b0d762844a71a29fe8139c1105d92f0cb
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
+  rubocop-rails (2.35.5) sha256=f00b3c936002ba8e9ac62e8607c54bb24cda44b36e41b9c7e4f3872e1b0f3fe3
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.4.0) sha256=6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
@@ -618,7 +618,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
-  version_gem (1.1.12) sha256=b78f691677807997e63901e8aba1b96d4ae172ce5570ad9ceb0208eb3a0edb3d
+  version_gem (1.1.13) sha256=77f3035ac45877cd14610648fec2d23bd8c10fa13dfcf63a588825aa98587260
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.1) sha256=5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96

--- a/ruby-on-rails/perfect-ruby-on-rails/rbs_collection.lock.yaml
+++ b/ruby-on-rails/perfect-ruby-on-rails/rbs_collection.lock.yaml
@@ -90,7 +90,7 @@ gems:
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: anonymous_loader
-  version: 0.1.1
+  version: 0.1.2
   source:
     type: rubygems
 - name: base64
@@ -478,7 +478,7 @@ gems:
   source:
     type: stdlib
 - name: version_gem
-  version: 1.1.12
+  version: 1.1.13
   source:
     type: rubygems
 - name: zlib

--- a/ruby-on-rails/restful-api/Gemfile
+++ b/ruby-on-rails/restful-api/Gemfile
@@ -63,7 +63,7 @@ group :development do
   gem 'rubocop', '~> 1.88.0', require: false
   gem 'rubocop-factory_bot', '~> 2.28.0', require: false
   gem 'rubocop-performance', '~> 1.26.0', require: false
-  gem 'rubocop-rails', '~> 2.35.4', require: false
+  gem 'rubocop-rails', '~> 2.35.5', require: false
   gem 'rubocop-rspec', '~> 3.10.2', require: false
   gem 'rubocop-rspec_rails', '~> 2.32.0', require: false
   # Typechecking

--- a/ruby-on-rails/restful-api/Gemfile.lock
+++ b/ruby-on-rails/restful-api/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -288,7 +288,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.4)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -370,7 +370,7 @@ DEPENDENCIES
   rubocop (~> 1.88.0)
   rubocop-factory_bot (~> 2.28.0)
   rubocop-performance (~> 1.26.0)
-  rubocop-rails (~> 2.35.4)
+  rubocop-rails (~> 2.35.5)
   rubocop-rspec (~> 3.10.2)
   rubocop-rspec_rails (~> 2.32.0)
   shoulda-matchers (~> 8.0.1)
@@ -450,7 +450,7 @@ CHECKSUMS
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
@@ -483,7 +483,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-factory_bot (2.28.0) sha256=4b17fc02124444173317e131759d195b0d762844a71a29fe8139c1105d92f0cb
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
+  rubocop-rails (2.35.5) sha256=f00b3c936002ba8e9ac62e8607c54bb24cda44b36e41b9c7e4f3872e1b0f3fe3
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   rubocop-rspec_rails (2.32.0) sha256=4a0d641c72f6ebb957534f539d9d0a62c47abd8ce0d0aeee1ef4701e892a9100
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33


### PR DESCRIPTION
## 1. Overview

This PR updates the Ruby Gem dependencies of the Ruby on Rails sub-projects in the `tutorials` repository, namely `e-navigator`, `perfect-ruby-on-rails` and `restful-api`.  
All bumps are patch-level. `rubocop-rails` (direct, lint toolchain) and `pp` (transitive) are updated across all three sub-projects, while `anonymous_loader` and `version_gem` are additionally updated in `perfect-ruby-on-rails`.  
`perfect-ruby-on-rails/rbs_collection.lock.yaml` was regenerated to track the new `anonymous_loader` and `version_gem` versions.

## 2. Key Changes & Differences in Each Gem

|Gems |Before |After |Changes & Differences |
|:-|:-|:-|:-|
| rubocop-rails | 2.35.4 | 2.35.5 | Bug fix: no longer raises an erroneous `Rails/SaveBang` offense when a persistence method is the final expression of a multiline method or block (#1379). Enhancement: `Rails/Env` now allows `Rails.env.local?` (#1617). Updated in all three sub-projects. |
| pp | 0.6.3 | 0.6.4 | Transitive dependency. Adds support for `private instance_variables_to_inspect`, suppresses documentation for internals, and adds a commit-sync workflow. Updated in all three sub-projects. |
| anonymous_loader | 0.1.1 | 0.1.2 | Adds support for JRuby 10.1 and TruffleRuby 34.0; retemplated project metadata and CI/development automation with `kettle-jem` v7.0.0. Updated in `perfect-ruby-on-rails`. |
| version_gem | 1.1.12 | 1.1.13 | Adds support for JRuby 10.1 and TruffleRuby 34.0; retemplated with `kettle-jem` v7.0.0; fixes RubyGems homepage and Open Collective metadata, and `.simplecov` bootstrap ordering. Updated in `perfect-ruby-on-rails`. |

## 3. Summary

Four gems were updated across the three Rails tutorial sub-projects, all at patch level.  
`rubocop-rails` and `pp` were bumped everywhere, delivering lint-accuracy fixes and minor inspection/internal improvements respectively.  
`anonymous_loader` and `version_gem` were bumped in `perfect-ruby-on-rails`, both mainly broadening Ruby engine support (JRuby 10.1 / TruffleRuby 34.0) and modernising development infrastructure; `version_gem` also corrects packaging metadata.  
The update is low-risk and requires no application code changes.

## 4. References

- [rubocop-rails v2.35.5 release](https://github.com/rubocop/rubocop-rails/releases/tag/v2.35.5)
- [pp gem releases](https://github.com/ruby/pp/releases)
- [anonymous_loader CHANGELOG](https://github.com/ruby-oauth/anonymous_loader/blob/main/CHANGELOG.md)
- [version_gem CHANGELOG](https://github.com/pboling/version_gem/blob/main/CHANGELOG.md)