### PR TITLE
[python] Update pip Library Dependencies

### DIFF
--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -3,7 +3,7 @@ autoflake8==0.4.1
 autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.11.0
+librt==0.12.0
 mccabe==0.7.0
 mypy==2.0.0
 mypy_extensions==1.1.0


### PR DESCRIPTION
## 1. Overview

This branch updates the project's pinned **pip** library dependencies for the Python toolchain.
The change is an automated dependency refresh that bumps the `librt` runtime library to its latest patch-compatible release.
It touches only the lock file (`python/requirements.lock`); no application or test code is modified.

## 2. Key Changes & Differences

| Library | Before | After | Changes & Differences |
|:-|:-|:-|:-|
| librt | 0.11.0 | 0.12.0 | Minor version bump (0.11.x → 0.12.x); picks up upstream fixes and improvements. No other pins changed. |

## 3. Summary

A single, low-risk dependency update isolated to `python/requirements.lock`.
`librt` moves from `0.11.0` to `0.12.0` while every other pinned package stays identical.
There is no source-code or CI-configuration impact, so the change is safe to merge once the standard Python workflow passes.

## 4. References

- [librt on PyPI](https://pypi.org/project/librt/)
- [pip — Requirements files](https://pip.pypa.io/en/stable/reference/requirements-file-format/)
- [Semantic Versioning](https://semver.org/)