### PR TITLE
[ruby-on-rails] Bump Docker from 29.5.4 to 29.6.1

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,7 +1,7 @@
 ## 1. Common Environment
 
 - MySQL Server 8.0.32
-- Docker 29.5.4
+- Docker 29.6.1
 
 ## 2. Reference
 

--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -4,7 +4,7 @@
 - Ruby 4.0.5
 - Gemfile 4.0.12
 - Bundler 4.0.12
-- Docker 29.5.4
+- Docker 29.6.1
 
 ## 2. READMEs
 


### PR DESCRIPTION
## 1. Overview

This branch is a documentation-only change.
It updates the Docker version referenced in two setup guides (`mysql/README.md` and `ruby-on-rails/README.md`) so the documented environment matches the current Docker release.
No code, gems, or configuration are affected.

## 2. Key Changes & Differences

| Component | Before | After  | Changes & Differences                                                                               |
| :-------- | :----- | :----- | :-------------------------------------------------------------------------------------------------- |
| Docker    | 29.5.4 | 29.6.1 | Version listed in the environment prerequisites of `mysql/README.md` and `ruby-on-rails/README.md`. |

## 3. Summary

The documented Docker version is bumped from **29.5.4** to **29.6.1** in both `mysql/README.md` and `ruby-on-rails/README.md`. This is a cosmetic/documentation change with no functional impact.

## 4. References

- [Docker Engine release notes](https://docs.docker.com/engine/release-notes/)
- [mysql/README.md](./mysql/README.md)
- [ruby-on-rails/README.md](./ruby-on-rails/README.md)