### PR TITLE
[Ruby on Rails] Configure Settings for Production

### DIFF
--- a/ruby-on-rails/e-navigator/.dockerignore
+++ b/ruby-on-rails/e-navigator/.dockerignore
@@ -1,6 +1,13 @@
 Dockerfile
+Dockerfile.production
 .dockerignore
 .git
+.kamal
+
+# Never bake local environment files or credential keys into images
+.env*
+!.env.sample
+config/master.key
 
 log/*
 tmp/*

--- a/ruby-on-rails/e-navigator/.kamal/secrets
+++ b/ruby-on-rails/e-navigator/.kamal/secrets
@@ -1,0 +1,18 @@
+# Secrets referenced by config/deploy.yml, resolved from the environment of the
+# shell that runs `kamal`. Export them (e.g. in ~/.bashrc on WSL) before deploying:
+#
+#   export KAMAL_REGISTRY_PASSWORD=<GitHub PAT with write:packages>
+#   export SECRET_KEY_BASE=$(openssl rand -hex 64)  # generate once and keep it stable
+#   export DB_PASSWORD=<MySQL root password for production>
+#   export MAILER_USER_ID=<Gmail SMTP user>
+#   export MAILER_PASSWORD=<Gmail SMTP app password>
+#
+# This file only references environment variables — never write literal secrets here.
+
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+SECRET_KEY_BASE=$SECRET_KEY_BASE
+DB_PASSWORD=$DB_PASSWORD
+# The app connects as root, so the accessory's root password is the same secret.
+MYSQL_ROOT_PASSWORD=$DB_PASSWORD
+MAILER_USER_ID=$MAILER_USER_ID
+MAILER_PASSWORD=$MAILER_PASSWORD

--- a/ruby-on-rails/e-navigator/Dockerfile.production
+++ b/ruby-on-rails/e-navigator/Dockerfile.production
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1
+
+# Production image built and deployed by Kamal (see config/deploy.yml).
+# Development keeps using ./Dockerfile via docker-compose.yml.
+ARG RUBY_VERSION=4.0.5
+FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
+
+WORKDIR /app
+
+# Install base packages
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl default-mysql-client libjemalloc2 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development test"
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git pkg-config && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+ARG BUNDLER_VERSION=4.0.15
+RUN gem install bundler -v $BUNDLER_VERSION --no-document
+
+# Install application gems
+COPY .ruby-version Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile --gemfile
+
+# Copy application code
+COPY . .
+
+# Windows checkouts can lose the executable bit; restore it for the bin stubs
+RUN chmod +x bin/*
+
+# Precompile bootsnap code for faster boot times
+RUN bundle exec bootsnap precompile app/ lib/
+
+# Precompile assets (Propshaft + importmap, no Node required) without the production secret key
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+
+# Final stage for app image
+FROM base
+
+# Copy built artifacts: gems, application
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --from=build /app /app
+
+# Run and own only the runtime files as a non-root user for security
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    mkdir -p db log storage tmp && \
+    chown -R rails:rails db log storage tmp
+USER 1000:1000
+
+# Entrypoint prepares the database before starting the server.
+ENTRYPOINT ["/app/bin/docker-entrypoint"]
+
+# kamal-proxy routes to this port (proxy.app_port in config/deploy.yml)
+EXPOSE 3000
+CMD ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/ruby-on-rails/e-navigator/Gemfile.lock
+++ b/ruby-on-rails/e-navigator/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
     globalid (1.4.0)
@@ -181,6 +182,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -361,6 +364,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -438,6 +442,7 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   factory_bot (6.6.0) sha256=1fc1b3b5620ec980a6a27aec1b6ec8c250ca82962e970e8a40f93e8d388d4b89
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
@@ -464,6 +469,7 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356

--- a/ruby-on-rails/e-navigator/bin/docker-entrypoint
+++ b/ruby-on-rails/e-navigator/bin/docker-entrypoint
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+# Enable jemalloc for reduced memory usage and latency.
+if [ -z "${LD_PRELOAD+x}" ]; then
+  LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
+  export LD_PRELOAD
+fi
+
+# If running the rails server then create or migrate existing database
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
+exec "${@}"

--- a/ruby-on-rails/e-navigator/config/database.yml
+++ b/ruby-on-rails/e-navigator/config/database.yml
@@ -18,7 +18,5 @@ test:
 
 production:
   <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
   database: e_navigator_production
+  password: <%= ENV.fetch("DB_PASSWORD") { '' } %>

--- a/ruby-on-rails/e-navigator/config/deploy.yml
+++ b/ruby-on-rails/e-navigator/config/deploy.yml
@@ -1,0 +1,63 @@
+# Kamal deployment configuration (https://kamal-deploy.org/docs/configuration/overview/).
+# First deploy: `kamal setup`. Subsequent deploys: `kamal deploy`. Run from WSL.
+service: e-navigator
+
+# Pushed to ghcr.io (see registry below) as ghcr.io/hayat01sh1da/e-navigator.
+image: hayat01sh1da/e-navigator
+
+servers:
+  web:
+    - 203.0.113.10 # TODO: replace with the Oracle Cloud VM public IP
+
+# kamal-proxy terminates SSL with a Let's Encrypt certificate for this host.
+proxy:
+  ssl: true
+  host: e-navigator.example.com # TODO: replace with the real hostname (must resolve to the VM IP)
+  app_port: 3000
+
+registry:
+  server: ghcr.io
+  username: hayat01sh1da
+  # GitHub personal access token with write:packages, read via .kamal/secrets.
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+builder:
+  # Oracle Cloud Always Free VM.Standard.A1.Flex is ARM (aarch64).
+  arch: arm64
+  dockerfile: Dockerfile.production
+
+env:
+  clear:
+    APP_HOST: e-navigator.example.com # TODO: keep in sync with proxy.host (used by Action Mailer URLs)
+    # config/environments/production.rb only serves /public when this is set;
+    # kamal-proxy does not serve static files itself.
+    RAILS_SERVE_STATIC_FILES: "1"
+    # Accessory containers are reachable by name on the shared kamal docker network.
+    DB_HOST: e-navigator-db
+    DB_USERNAME: root
+  secret:
+    - SECRET_KEY_BASE
+    - DB_PASSWORD
+    - MAILER_USER_ID
+    - MAILER_PASSWORD
+
+# MySQL runs on the same VM as a Kamal accessory. No host port is published;
+# the app reaches it over the kamal docker network only.
+accessories:
+  db:
+    image: mysql:8.4
+    host: 203.0.113.10 # TODO: replace with the Oracle Cloud VM public IP
+    env:
+      clear:
+        MYSQL_DATABASE: e_navigator_production
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    directories:
+      - data:/var/lib/mysql
+
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell: app exec --interactive --reuse "bash"
+  logs: app logs -f
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"

--- a/ruby-on-rails/e-navigator/config/environments/production.rb
+++ b/ruby-on-rails/e-navigator/config/environments/production.rb
@@ -57,7 +57,10 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: ENV.fetch('APP_HOST', 'e-navigator.example.com'), protocol: 'https' }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('APP_HOST', 'e-navigator.example.com'),
+    protocol: 'https'
+  }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     user_name: ENV.fetch('MAILER_USER_ID', nil),

--- a/ruby-on-rails/e-navigator/config/environments/production.rb
+++ b/ruby-on-rails/e-navigator/config/environments/production.rb
@@ -46,18 +46,18 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :mem_cache_store
+  # Single-container Kamal deployment: no memcached on the host, so keep the in-process store.
+  config.cache_store = :memory_store
 
-  # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :resque
+  # Single-container Kamal deployment: no Redis/Resque on the host, so run jobs in-process.
+  config.active_job.queue_adapter = :async
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: 'e-navigator-hayato-ishida.herokuapp.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: ENV.fetch('APP_HOST', 'e-navigator.example.com'), protocol: 'https' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     user_name: ENV.fetch('MAILER_USER_ID', nil),

--- a/ruby-on-rails/e-navigator/config/routes.rb
+++ b/ruby-on-rails/e-navigator/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Used by kamal-proxy for zero-downtime deploy health checks.
+  get 'up' => 'rails/health#show', as: :rails_health_check
+
   devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions',

--- a/ruby-on-rails/perfect-ruby-on-rails/.dockerignore
+++ b/ruby-on-rails/perfect-ruby-on-rails/.dockerignore
@@ -1,6 +1,13 @@
 Dockerfile
+Dockerfile.production
 .dockerignore
 .git
+.kamal
+
+# Never bake local environment files or credential keys into images
+.env*
+!.env.sample
+config/master.key
 
 log/*
 tmp/*

--- a/ruby-on-rails/perfect-ruby-on-rails/.kamal/secrets
+++ b/ruby-on-rails/perfect-ruby-on-rails/.kamal/secrets
@@ -1,0 +1,18 @@
+# Secrets referenced by config/deploy.yml, resolved from the environment of the
+# shell that runs `kamal`. Export them (e.g. in ~/.bashrc on WSL) before deploying:
+#
+#   export KAMAL_REGISTRY_PASSWORD=<GitHub PAT with write:packages>
+#   export DB_PASSWORD=<MySQL root password for production>
+#   export OAUTH_CLIENT_ID=<GitHub OAuth app client id>
+#   export OAUTH_CLIENT_SECRET=<GitHub OAuth app client secret>
+#
+# RAILS_MASTER_KEY is read straight from config/master.key (kept out of git and images).
+# This file only references environment variables/files — never write literal secrets here.
+
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+RAILS_MASTER_KEY=$(cat config/master.key)
+DB_PASSWORD=$DB_PASSWORD
+# The app connects as root, so the accessory's root password is the same secret.
+MYSQL_ROOT_PASSWORD=$DB_PASSWORD
+OAUTH_CLIENT_ID=$OAUTH_CLIENT_ID
+OAUTH_CLIENT_SECRET=$OAUTH_CLIENT_SECRET

--- a/ruby-on-rails/perfect-ruby-on-rails/Dockerfile.production
+++ b/ruby-on-rails/perfect-ruby-on-rails/Dockerfile.production
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1
+
+# Production image built and deployed by Kamal (see config/deploy.yml).
+# Development keeps using ./Dockerfile via docker-compose.yml.
+FROM docker.io/library/node:26.4.0-slim AS node
+
+ARG RUBY_VERSION=4.0.5
+FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
+
+WORKDIR /app
+
+# Install base packages (libvips for Active Storage image processing)
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl default-mysql-client libjemalloc2 libvips && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development test"
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+# Install packages needed to build gems and Node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git pkg-config && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Node.js + pnpm are only needed at build time (jsbundling/cssbundling)
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs && \
+    ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    npm install -g pnpm@11.9.0
+
+ARG BUNDLER_VERSION=4.0.15
+RUN gem install bundler -v $BUNDLER_VERSION --no-document
+
+# Install Node modules
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Install application gems
+COPY .ruby-version Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile --gemfile
+
+# Copy application code
+COPY . .
+
+# Windows checkouts can lose the executable bit; restore it for the bin stubs
+RUN chmod +x bin/*
+
+# Precompile bootsnap code for faster boot times
+RUN bundle exec bootsnap precompile app/ lib/
+
+# Precompile assets (runs esbuild + sass via jsbundling/cssbundling) without the production secret key
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+
+# Node modules are bundled into app/assets/builds by the precompile; drop the sources
+RUN rm -rf node_modules
+
+# Final stage for app image
+FROM base
+
+# Copy built artifacts: gems, application
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --from=build /app /app
+
+# Run and own only the runtime files as a non-root user for security
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    mkdir -p db log storage tmp && \
+    chown -R rails:rails db log storage tmp
+USER 1000:1000
+
+# Entrypoint prepares the database before starting the server.
+ENTRYPOINT ["/app/bin/docker-entrypoint"]
+
+# kamal-proxy routes to this port (proxy.app_port in config/deploy.yml)
+EXPOSE 3000
+CMD ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
+++ b/ruby-on-rails/perfect-ruby-on-rails/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
     globalid (1.4.0)
@@ -209,6 +210,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.24)
@@ -421,6 +424,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -513,6 +517,7 @@ CHECKSUMS
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
@@ -548,6 +553,7 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   oauth2 (2.0.24) sha256=3d4864983ab9fb7d3c836bca9635ef7b347631918fa890fcd9793d40ec82c186
   observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac

--- a/ruby-on-rails/perfect-ruby-on-rails/bin/docker-entrypoint
+++ b/ruby-on-rails/perfect-ruby-on-rails/bin/docker-entrypoint
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+# Enable jemalloc for reduced memory usage and latency.
+if [ -z "${LD_PRELOAD+x}" ]; then
+  LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
+  export LD_PRELOAD
+fi
+
+# If running the rails server then create or migrate existing database
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
+exec "${@}"

--- a/ruby-on-rails/perfect-ruby-on-rails/config/database.yml
+++ b/ruby-on-rails/perfect-ruby-on-rails/config/database.yml
@@ -18,7 +18,5 @@ test:
 
 production:
   <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
   database: perfect_ruby_on_rails_production
+  password: <%= ENV.fetch("DB_PASSWORD") { '' } %>

--- a/ruby-on-rails/perfect-ruby-on-rails/config/deploy.yml
+++ b/ruby-on-rails/perfect-ruby-on-rails/config/deploy.yml
@@ -1,0 +1,66 @@
+# Kamal deployment configuration (https://kamal-deploy.org/docs/configuration/overview/).
+# First deploy: `kamal setup`. Subsequent deploys: `kamal deploy`. Run from WSL.
+service: perfect-ruby-on-rails
+
+# Pushed to ghcr.io (see registry below) as ghcr.io/hayat01sh1da/perfect-ruby-on-rails.
+image: hayat01sh1da/perfect-ruby-on-rails
+
+servers:
+  web:
+    - 203.0.113.10 # TODO: replace with the Oracle Cloud VM public IP
+
+# kamal-proxy terminates SSL with a Let's Encrypt certificate for this host.
+proxy:
+  ssl: true
+  host: perfect-ruby-on-rails.example.com # TODO: replace with the real hostname (must resolve to the VM IP)
+  app_port: 3000
+
+registry:
+  server: ghcr.io
+  username: hayat01sh1da
+  # GitHub personal access token with write:packages, read via .kamal/secrets.
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+builder:
+  # Oracle Cloud Always Free VM.Standard.A1.Flex is ARM (aarch64).
+  arch: arm64
+  dockerfile: Dockerfile.production
+
+env:
+  clear:
+    APP_HOST: perfect-ruby-on-rails.example.com # TODO: keep in sync with proxy.host (used by Action Mailer URLs)
+    # Accessory containers are reachable by name on the shared kamal docker network.
+    DB_HOST: perfect-ruby-on-rails-db
+    DB_USERNAME: root
+  secret:
+    - RAILS_MASTER_KEY
+    - DB_PASSWORD
+    # Register the deployed callback URL (https://<host>/auth/github/callback)
+    # in the GitHub OAuth app these credentials belong to.
+    - OAUTH_CLIENT_ID
+    - OAUTH_CLIENT_SECRET
+
+# Active Storage uses the :local disk service; keep uploads across deploys.
+volumes:
+  - "perfect_ruby_on_rails_storage:/app/storage"
+
+# MySQL runs on the same VM as a Kamal accessory. No host port is published;
+# the app reaches it over the kamal docker network only.
+accessories:
+  db:
+    image: mysql:8.4
+    host: 203.0.113.10 # TODO: replace with the Oracle Cloud VM public IP
+    env:
+      clear:
+        MYSQL_DATABASE: perfect_ruby_on_rails_production
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    directories:
+      - data:/var/lib/mysql
+
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell: app exec --interactive --reuse "bash"
+  logs: app logs -f
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"

--- a/ruby-on-rails/perfect-ruby-on-rails/config/environments/production.rb
+++ b/ruby-on-rails/perfect-ruby-on-rails/config/environments/production.rb
@@ -48,18 +48,18 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :mem_cache_store
+  # Single-container Kamal deployment: no memcached on the host, so keep the in-process store.
+  config.cache_store = :memory_store
 
-  # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :resque
+  # Single-container Kamal deployment: no Redis/Resque on the host, so run jobs in-process.
+  config.active_job.queue_adapter = :async
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: 'example.com' }
+  config.action_mailer.default_url_options = { host: ENV.fetch('APP_HOST', 'example.com') }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/ruby-on-rails/perfect-ruby-on-rails/config/routes.rb
+++ b/ruby-on-rails/perfect-ruby-on-rails/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Used by kamal-proxy for zero-downtime deploy health checks.
+  get 'up' => 'rails/health#show', as: :rails_health_check
+
   root   'events#index'
   get    '/status'                  => 'status#index', defaults: { format: :json }
   get    '/auth/:provider/callback' => 'sessions#create'

--- a/ruby-on-rails/restful-api/.dockerignore
+++ b/ruby-on-rails/restful-api/.dockerignore
@@ -1,6 +1,13 @@
 Dockerfile
+Dockerfile.production
 .dockerignore
 .git
+.kamal
+
+# Never bake local environment files or credential keys into images
+.env*
+!.env.sample
+config/master.key
 
 log/*
 tmp/*

--- a/ruby-on-rails/restful-api/.kamal/secrets
+++ b/ruby-on-rails/restful-api/.kamal/secrets
@@ -1,0 +1,14 @@
+# Secrets referenced by config/deploy.yml, resolved from the environment of the
+# shell that runs `kamal`. Export them (e.g. in ~/.bashrc on WSL) before deploying:
+#
+#   export KAMAL_REGISTRY_PASSWORD=<GitHub PAT with write:packages>
+#   export DB_PASSWORD=<MySQL root password for production>
+#
+# RAILS_MASTER_KEY is read straight from config/master.key (kept out of git and images).
+# This file only references environment variables/files — never write literal secrets here.
+
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+RAILS_MASTER_KEY=$(cat config/master.key)
+DB_PASSWORD=$DB_PASSWORD
+# The app connects as root, so the accessory's root password is the same secret.
+MYSQL_ROOT_PASSWORD=$DB_PASSWORD

--- a/ruby-on-rails/restful-api/Dockerfile.production
+++ b/ruby-on-rails/restful-api/Dockerfile.production
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+# Production image built and deployed by Kamal (see config/deploy.yml).
+# Development keeps using ./Dockerfile via docker-compose.yml.
+ARG RUBY_VERSION=4.0.5
+FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
+
+WORKDIR /app
+
+# Install base packages
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl default-mysql-client libjemalloc2 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development test"
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git pkg-config && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+ARG BUNDLER_VERSION=4.0.15
+RUN gem install bundler -v $BUNDLER_VERSION --no-document
+
+# Install application gems
+COPY .ruby-version Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile --gemfile
+
+# Copy application code
+COPY . .
+
+# Windows checkouts can lose the executable bit; restore it for the bin stubs
+RUN chmod +x bin/*
+
+# Precompile bootsnap code for faster boot times
+# (API-only app with no asset pipeline, so there is no assets:precompile step.)
+RUN bundle exec bootsnap precompile app/ lib/
+
+# Final stage for app image
+FROM base
+
+# Copy built artifacts: gems, application
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --from=build /app /app
+
+# Run and own only the runtime files as a non-root user for security
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    mkdir -p db log storage tmp && \
+    chown -R rails:rails db log storage tmp
+USER 1000:1000
+
+# Entrypoint prepares the database before starting the server.
+ENTRYPOINT ["/app/bin/docker-entrypoint"]
+
+# kamal-proxy routes to this port (proxy.app_port in config/deploy.yml)
+EXPOSE 3000
+CMD ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/ruby-on-rails/restful-api/Gemfile.lock
+++ b/ruby-on-rails/restful-api/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
     globalid (1.4.0)
@@ -171,6 +172,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     observer (0.1.2)
@@ -341,6 +344,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -417,6 +421,7 @@ CHECKSUMS
   factory_bot (6.6.0) sha256=1fc1b3b5620ec980a6a27aec1b6ec8c250ca82962e970e8a40f93e8d388d4b89
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
@@ -442,6 +447,7 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912

--- a/ruby-on-rails/restful-api/bin/docker-entrypoint
+++ b/ruby-on-rails/restful-api/bin/docker-entrypoint
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+# Enable jemalloc for reduced memory usage and latency.
+if [ -z "${LD_PRELOAD+x}" ]; then
+  LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
+  export LD_PRELOAD
+fi
+
+# If running the rails server then create or migrate existing database
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
+exec "${@}"

--- a/ruby-on-rails/restful-api/config/database.yml
+++ b/ruby-on-rails/restful-api/config/database.yml
@@ -18,7 +18,5 @@ test:
 
 production:
   <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
   database: restful_api_rails_production
+  password: <%= ENV.fetch("DB_PASSWORD") { '' } %>

--- a/ruby-on-rails/restful-api/config/deploy.yml
+++ b/ruby-on-rails/restful-api/config/deploy.yml
@@ -1,0 +1,61 @@
+# Kamal deployment configuration (https://kamal-deploy.org/docs/configuration/overview/).
+# First deploy: `kamal setup`. Subsequent deploys: `kamal deploy`. Run from WSL.
+service: restful-api
+
+# Pushed to ghcr.io (see registry below) as ghcr.io/hayat01sh1da/restful-api.
+image: hayat01sh1da/restful-api
+
+servers:
+  web:
+    - 203.0.113.10 # TODO: replace with the Oracle Cloud VM public IP
+
+# kamal-proxy terminates SSL with a Let's Encrypt certificate for this host.
+proxy:
+  ssl: true
+  host: restful-api.example.com # TODO: replace with the real hostname (must resolve to the VM IP)
+  app_port: 3000
+
+registry:
+  server: ghcr.io
+  username: hayat01sh1da
+  # GitHub personal access token with write:packages, read via .kamal/secrets.
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+builder:
+  # Oracle Cloud Always Free VM.Standard.A1.Flex is ARM (aarch64).
+  arch: arm64
+  dockerfile: Dockerfile.production
+
+env:
+  clear:
+    # Accessory containers are reachable by name on the shared kamal docker network.
+    DB_HOST: restful-api-db
+    DB_USERNAME: root
+  secret:
+    - RAILS_MASTER_KEY
+    - DB_PASSWORD
+
+# Active Storage uses the :local disk service; keep uploads across deploys.
+volumes:
+  - "restful_api_storage:/app/storage"
+
+# MySQL runs on the same VM as a Kamal accessory. No host port is published;
+# the app reaches it over the kamal docker network only.
+accessories:
+  db:
+    image: mysql:8.4
+    host: 203.0.113.10 # TODO: replace with the Oracle Cloud VM public IP
+    env:
+      clear:
+        MYSQL_DATABASE: restful_api_rails_production
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    directories:
+      - data:/var/lib/mysql
+
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell: app exec --interactive --reuse "bash"
+  logs: app logs -f
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"

--- a/ruby-on-rails/restful-api/config/environments/production.rb
+++ b/ruby-on-rails/restful-api/config/environments/production.rb
@@ -45,11 +45,11 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :mem_cache_store
+  # Single-container Kamal deployment: no memcached on the host, so keep the in-process store.
+  config.cache_store = :memory_store
 
-  # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :resque
+  # Single-container Kamal deployment: no Redis/Resque on the host, so run jobs in-process.
+  config.active_job.queue_adapter = :async
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/ruby-on-rails/restful-api/config/routes.rb
+++ b/ruby-on-rails/restful-api/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Used by kamal-proxy for zero-downtime deploy health checks.
+  get 'up' => 'rails/health#show', as: :rails_health_check
+
   # module the controllers without affecting the URI
   scope module: :v2, constraints: ApiVersion.new('v2') do
     resources :todos, only: :index


### PR DESCRIPTION
## 1. Overview

This branch configures the three Rails apps under `ruby-on-rails/` (`e-navigator`, `perfect-ruby-on-rails`, `restful-api`) for production deployment to a single Oracle Cloud "Always Free" ARM VM (VM.Standard.A1.Flex) with Kamal, where kamal-proxy routes to each app by hostname.  
It fixes production settings that would have prevented boot in every app: `mem_cache_store` and the Resque Active Job adapter were configured without the `dalli`/`resque` gems, and the production database sections overrode the adapter to `postgresql` (a Heroku-era leftover) while only `mysql2` is bundled. It also adds the `/up` health check endpoint kamal-proxy relies on for zero-downtime deploys, and introduces per-app production images and Kamal deployment configuration. Each app's development `Dockerfile`/`docker-compose.yml` workflow is untouched.

## 2. Key Changes & Differences

|Files (all three apps) |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`config/routes.rb` |No health check route |`GET /up` -> `rails/health#show` |kamal-proxy polls `/up` to gate zero-downtime deploys |
|`config/environments/production.rb` |`cache_store = :mem_cache_store` / `queue_adapter = :resque` (gems not bundled; production boot failure) |`cache_store = :memory_store` / `queue_adapter = :async` |In-process backends suited to a single-container deployment; Action Mailer host is now environment-driven via `APP_HOST` (e-navigator previously pointed at a defunct herokuapp.com domain) |
|`config/database.yml` |`production` overrode the adapter to `postgresql` with no `pg` gem |`production` inherits the `mysql2` defaults; password from `DB_PASSWORD`, host from `DB_HOST` |Production connects to the Kamal MySQL accessory on the internal Docker network |
|`Gemfile.lock` |`PLATFORMS: x86_64-linux` only |`aarch64-linux` added |Frozen bundle install succeeds when building the ARM images for the Oracle Cloud A1 VM |
|`.dockerignore` |`.env*` and `config/master.key` copied into images |Both excluded, plus `.kamal` and `Dockerfile.production` |Local environment files and credential keys are never baked into registry images |
|`Dockerfile.production` |N/A (only the development Dockerfiles ending in `CMD ["bash"]`) |Multi-stage slim production images: non-root user, jemalloc, bootsnap; Node 26 + pnpm build stage for perfect-ruby-on-rails (esbuild/sass), no asset stage for the API-only restful-api |New; used by Kamal only, development keeps `./Dockerfile` |
|`bin/docker-entrypoint` |N/A |Entrypoint enabling jemalloc and running `db:prepare` before the server starts |New; referenced by `Dockerfile.production` |
|`config/deploy.yml` |N/A |Kamal config per app: `arm64` builder, `ghcr.io/hayat01sh1da/<app>` image, kamal-proxy SSL, `mysql:8.4` accessory with persistent data directory, Active Storage volume where applicable |New; `TODO` placeholders remain for the VM IP and hostnames |
|`.kamal/secrets` |N/A |Maps registry/DB/app secrets from the deploying shell's environment (`RAILS_MASTER_KEY` read from `config/master.key` where present) |New; contains environment-variable references only, no literal secrets |

## 3. Summary

- 15 files modified and 12 files added across 6 commits; all three apps are now bootable and deployable in production on one Always Free VM.  
- Follow-up actions before the first deploy: replace the `TODO` placeholders in each `config/deploy.yml` (Oracle Cloud VM public IP and hostnames), export the secrets listed in each `.kamal/secrets` in the deploying WSL shell, register the production OAuth callback URL for perfect-ruby-on-rails' GitHub OAuth app, then run `kamal setup` per app.  
- Operational notes: images are cross-built for `linux/arm64` and pushed to ghcr.io; each MySQL accessory publishes no host port and is reachable only on the internal Docker network; the first boot of a MySQL-backed app can race MySQL initialisation — rerun `kamal deploy` if `db:prepare` fails.

## 4. References

- [e-navigator/config/routes.rb](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/e-navigator/config/routes.rb)
- [e-navigator/config/environments/production.rb](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/e-navigator/config/environments/production.rb)
- [e-navigator/config/database.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/e-navigator/config/database.yml)
- [e-navigator/Dockerfile.production](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/e-navigator/Dockerfile.production)
- [e-navigator/config/deploy.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/e-navigator/config/deploy.yml)
- [e-navigator/.kamal/secrets](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/e-navigator/.kamal/secrets)
- [perfect-ruby-on-rails/config/routes.rb](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/perfect-ruby-on-rails/config/routes.rb)
- [perfect-ruby-on-rails/config/environments/production.rb](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/perfect-ruby-on-rails/config/environments/production.rb)
- [perfect-ruby-on-rails/config/database.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/perfect-ruby-on-rails/config/database.yml)
- [perfect-ruby-on-rails/Dockerfile.production](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/perfect-ruby-on-rails/Dockerfile.production)
- [perfect-ruby-on-rails/config/deploy.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/perfect-ruby-on-rails/config/deploy.yml)
- [perfect-ruby-on-rails/.kamal/secrets](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/perfect-ruby-on-rails/.kamal/secrets)
- [restful-api/config/routes.rb](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/restful-api/config/routes.rb)
- [restful-api/config/environments/production.rb](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/restful-api/config/environments/production.rb)
- [restful-api/config/database.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/restful-api/config/database.yml)
- [restful-api/Dockerfile.production](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/restful-api/Dockerfile.production)
- [restful-api/config/deploy.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/restful-api/config/deploy.yml)
- [restful-api/.kamal/secrets](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/ruby-on-rails/configure-settings-for-production/ruby-on-rails/restful-api/.kamal/secrets)
- [Kamal documentation](https://kamal-deploy.org/docs/configuration/overview/)
- [Oracle Cloud Always Free resources](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)
- [Rails Health Check endpoint](https://api.rubyonrails.org/classes/Rails/HealthController.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
