### PR TITLE
[github-actions] Bump actions/checkout Version from v6 to v7

### DIFF
--- a/.github/workflows/javascript--ci.yml
+++ b/.github/workflows/javascript--ci.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       javascript-changes: ${{ steps.change-detection.outputs.javascript }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -52,7 +52,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.javascript-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-nodejs
         with:
           working-directory: ./javascript

--- a/.github/workflows/javascript--daily-dependencies-update.yml
+++ b/.github/workflows/javascript--daily-dependencies-update.yml
@@ -28,7 +28,7 @@ jobs:
           - reactjs
           - ruby-on-rails/perfect-ruby-on-rails
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-nodejs
         with:
           working-directory: ${{ matrix.app }}
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: update_pnpm_package_dependencies
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           pattern: pnpm-dependency-changes-*

--- a/.github/workflows/python--ci.yml
+++ b/.github/workflows/python--ci.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       python-changes: ${{ steps.change-detection.outputs.python }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -55,7 +55,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.python-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: flake8
         working-directory: ./python
@@ -70,7 +70,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.python-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: pytest
         working-directory: ./python
@@ -81,7 +81,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.python-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: mypy
         working-directory: ./python

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: Update pip Library Dependencies
         working-directory: ./python

--- a/.github/workflows/ruby-on-rails--daily-dependencies-update.yml
+++ b/.github/workflows/ruby-on-rails--daily-dependencies-update.yml
@@ -26,7 +26,7 @@ jobs:
           - ruby-on-rails/perfect-ruby-on-rails
           - ruby-on-rails/restful-api
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ${{ matrix.app }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: update_gem_dependencies
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           pattern: gem-dependency-changes-*

--- a/.github/workflows/ruby-on-rails--e-navigator--ci.yml
+++ b/.github/workflows/ruby-on-rails--e-navigator--ci.yml
@@ -63,7 +63,7 @@ jobs:
       rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
       steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -114,7 +114,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator
@@ -128,7 +128,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator
@@ -142,7 +142,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.rubocop-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator
@@ -156,7 +156,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.steep-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/e-navigator

--- a/.github/workflows/ruby-on-rails--perfect-ruby-on-rails--ci.yml
+++ b/.github/workflows/ruby-on-rails--perfect-ruby-on-rails--ci.yml
@@ -68,7 +68,7 @@ jobs:
       rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
       steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -131,7 +131,7 @@ jobs:
           - 3306:3306
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-nodejs
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails
@@ -151,7 +151,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails
@@ -165,7 +165,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.rubocop-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails
@@ -179,7 +179,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.steep-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/perfect-ruby-on-rails

--- a/.github/workflows/ruby-on-rails--restful-api--ci.yml
+++ b/.github/workflows/ruby-on-rails--restful-api--ci.yml
@@ -55,7 +55,7 @@ jobs:
       rubocop-changes: ${{ steps.change-detection.outputs.rubocop}}
       steep-changes: ${{ steps.change-detection.outputs.steep}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -112,7 +112,7 @@ jobs:
           - 3306:3306
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api
@@ -126,7 +126,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api
@@ -140,7 +140,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.rubocop-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api
@@ -154,7 +154,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.steep-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-ruby-on-rails
         with:
           working-directory: ./ruby-on-rails/restful-api

--- a/.github/workflows/typescript--ci.yml
+++ b/.github/workflows/typescript--ci.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       typescript-changes: ${{ steps.change-detection.outputs.typescript }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -52,7 +52,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.typescript-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-nodejs
         with:
           working-directory: ./typescript


### PR DESCRIPTION
## 1. Overview

The primary difference between actions/checkout@v6 and actions/checkout@v7 is a critical security enforcement that blocks untrusted code execution from fork pull requests by default.

## 2. Key Differences Overview

- **Fork Pull Request Protection (Breaking Change)**: v7 refuses to check out fork pull request code when a workflow is triggered by `pull_request_target` or `workflow_run`. This stops "pwn request" supply-chain attacks, where malicious actors use a fork PR to run unauthorized code with your base repository's elevated `GITHUB_TOKEN` and secrets.
- New Configuration Input: v7 introduces the `allow-unsafe-pr-checkout` flag. You must explicitly set this to `true` if your workflow deliberately requires checking out untrusted code from a fork under privileged triggers.
- **Under-the-Hood Migration**: `v7` shifts the entire action to **ECMAScript Modules (ESM)** to accommodate newer `@actions/*` internal package requirements.
- **Dependency & Security Patches**: `v7` includes major direct and transitive dependency updates to remediate known vulnerabilities.

## 3. Comparison of Key Features

|Feature / Behavior |actions/checkout@v6 |actions/checkout@v7 |
|:-|:-|:-|
**|Fork checkouts on `pull_request_target`** |Allowed automatically (Vulnerable to exploit) |**Blocked by default** (Throws an error) |
|**New Input: `allow-unsafe-pr-checkout`** |Not available |**Available** (Defaults to `false`) |
|I**nternal Module System** |CommonJS (CJS) |**ECMAScript Modules (ESM)** |
|**Credential Persistence Strategy** |Saved in `$RUNNER_TEMP` via `includeIf` |Saved in `$RUNNER_TEMP` via `includeIf` |

## 4. References

- [actions/checkout: Action for checking out a repo - GitHub](https://github.com/actions/checkout)
- [pull_request_targetでcheckoutできなくなった - Zenn](https://zenn.dev/catatsuy/scraps/9142e8c6b7a5cd)
- [Safer pull_request_target defaults for GitHub Actions checkout - The GitHub Blog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)
- [GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns - The Hacker News](https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html)
- [GitHub Actions checkout v7 improves security defaults - Linkedin](https://www.linkedin.com/posts/github-securitylab_a-step-towards-making-github-actions-more-activity-7473412207435874304-EsN8)