### PR TITLE
[JavaScript] Mirror the Latest pnpm Version

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,7 +1,7 @@
 ## 1. Environment
 
 - Node v26.5.0
-- pnpm 11.13.0
+- pnpm 11.15.0
 
 ## 2. Reference
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "javascript_primer",
   "version": "1.0.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.13.0",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.15.0",
   "main": "index.js",
   "scripts": {
     "test": "mocha nodejs/test/"

--- a/ruby-on-rails/perfect-ruby-on-rails/README.md
+++ b/ruby-on-rails/perfect-ruby-on-rails/README.md
@@ -1,7 +1,7 @@
 ## 1. Environment
 
 - Node v26.5.0
-- pnpm 11.13.0
+- pnpm 11.15.0
 
 ## 2. Reference
 

--- a/ruby-on-rails/perfect-ruby-on-rails/package.json
+++ b/ruby-on-rails/perfect-ruby-on-rails/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perfect_ruby_on_rails",
   "version": "0.1.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.13.0",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.15.0",
   "private": true,
   "dependencies": {
     "@hotwired/turbo-rails": "^8.0.23",

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,7 +2,7 @@
 
 - WSL (Ubuntu 25.10)
 - Node v26.5.0
-- pnpm 11.13.0
+- pnpm 11.15.0
 
 ## 2. Reference
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "javascript_primer",
   "version": "1.0.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.13.0",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.15.0",
   "main": "index.js",
   "scripts": {
     "test": "mocha nodejs/test/"


### PR DESCRIPTION
## 1. Overview

`pnpm` has already been bumped the latest version `11.15.0`, but it has not been reflected documents.
It should be mirrored.

## 2. Key Changes & Differences

|Code/Library/Package |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|javascript/README.md |11.13.0 |11.15.0 |The latest version mirrored |
|javascript/package.json |11.13.0 |11.15.0 |The latest version mirrored |
|ruby-on-rails-/perfect-ruby-on-rails/README.md |11.13.0 |11.15.0 |The latest version mirrored |
|ruby-on-rails-/perfect-ruby-on-rails//package.json |11.13.0 |11.15.0 |The latest version mirrored |
|typescript/README.md |11.13.0 |11.15.0 |The latest version mirrored |
|typescript/package.json |11.13.0 |11.15.0 |The latest version mirrored |

## 3. Summary

- The latest version of `pnpm v11.15.0` has been mirrored 

## 4. References

- [pnpm > Releases > 11.15](https://github.com/pnpm/pnpm/releases/tag/v11.15.0)
- [Diffs between v11.13.0 and v11.15.0](https://github.com/pnpm/pnpm/compare/v11.13.0...v11.15.0)