### PR TITLE
[JavaScript] Bump pnpm from 11.16.0 to 11.17.0

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,7 +1,7 @@
 ## 1. Environment
 
 - Node v26.5.0
-- pnpm 11.16.0
+- pnpm 11.17.0
 
 ## 2. Reference
 

--- a/ruby-on-rails/perfect-ruby-on-rails/README.md
+++ b/ruby-on-rails/perfect-ruby-on-rails/README.md
@@ -1,7 +1,7 @@
 ## 1. Environment
 
 - Node v26.5.0
-- pnpm 11.16.0
+- pnpm 11.17.0
 
 ## 2. Reference
 

--- a/ruby-on-rails/perfect-ruby-on-rails/package.json
+++ b/ruby-on-rails/perfect-ruby-on-rails/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perfect_ruby_on_rails",
   "version": "0.1.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.16.0",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.17.0",
   "private": true,
   "dependencies": {
     "@hotwired/turbo-rails": "^8.0.23",

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,7 +2,7 @@
 
 - WSL (Ubuntu 25.10)
 - Node v26.5.0
-- pnpm 11.16.0
+- pnpm 11.17.0
 
 ## 2. Reference
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "javascript_primer",
   "version": "1.0.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.16.0",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.5.0 * pnpm 11.17.0",
   "main": "index.js",
   "scripts": {
     "test": "mocha nodejs/test/"


### PR DESCRIPTION
## 1. Overview

This Pull Request adopts pnpm 11.17.0, released on 2026-07-23, in place of pnpm 11.16.0, released only a day earlier on 2026-07-22.  
There is no intermediate patch release, so the whole delta is the single `pnpm 11.17` release.  

The headline reason to take it is a packaging fix: the tarballs published for v11.13.1 through v11.16.0 were missing most of their compiled files because of a packing bug, and 11.17.0 republishes every package correctly ([#13164](https://github.com/pnpm/pnpm/issues/13164)).  
The release also adds the `update.githubActionsServer` setting for GitHub Enterprise Server users, stops `pnpm outdated` and `pnpm update` from failing on unreadable GitHub Action refs, and hardens web-based registry authentication against a memory-exhaustion vector ([#12721](https://github.com/pnpm/pnpm/issues/12721)).  

In this repository the upgrade lands as a documentation and metadata bump across the four pnpm-managed workspaces: `corepack use pnpm@latest` had already moved every authoritative `packageManager` pin to `pnpm@11.17.0+sha512.cca3…`, and this branch realigns the places the environment is written for a human to read.  

## 2. Key Changes & Differences

|Package / Feature |Before (11.16.0) |After (11.17.0) |Changes & Differences |
|:-|:-|:-|:-|
|pnpm |11.16.0 (released 2026-07-22) |11.17.0 (released 2026-07-23) |One minor release forward, comprising 1 minor change and 6 patch changes. Pinned through Corepack via the `packageManager` field of `javascript`, `typescript`, `reactjs` and `ruby-on-rails/perfect-ruby-on-rails`, so the version is enforced for every contributor and every CI run. |
|Published tarballs |v11.13.1 – v11.16.0 tarballs shipped without most of their compiled files, due to a packing bug |Every package republished with its complete compiled output |The most consequential fix in the release: 11.16.0 itself is one of the defective publishes, so this bump moves the repository off a broken artefact rather than merely gaining features ([#13164](https://github.com/pnpm/pnpm/issues/13164)). |
|`update.githubActionsServer` |No such setting; the GitHub server hosting Action repositories was not configurable |New setting accepting an `https://` or `http://` base URL, falling back to `$GITHUB_SERVER_URL` and then `https://github.com` |Lets `pnpm outdated` / `pnpm update` resolve GitHub Actions hosted on a GitHub Enterprise Server instead of assuming github.com ([#13220](https://github.com/pnpm/pnpm/issues/13220)). |
|GitHub Action ref resolution |`pnpm outdated` and `pnpm update` failed outright when an Action repository's refs could not be read (private repo, different server) |Such Actions are skipped with a warning |Turns a hard failure into a recoverable warning, so a single unreadable Action no longer aborts a dependency check ([#13220](https://github.com/pnpm/pnpm/issues/13220)). |
|`update.githubActions: false` |Disabling the flag did not stop `pnpm outdated` and interactive `pnpm update` from inspecting GitHub Actions |Both now skip GitHub Actions dependencies entirely |Makes the existing opt-out actually honoured across both commands ([#13220](https://github.com/pnpm/pnpm/issues/13220)). |
|Web-based authentication (token poll) |The poll read the response body of non-OK and still-pending (HTTP 202) responses, with no size cap |Non-OK / HTTP 202 bodies are not read at all, and the token response body is capped at 64 KiB |Security hardening: a malicious or compromised registry can no longer exhaust client memory through the authentication poll ([#12721](https://github.com/pnpm/pnpm/issues/12721)). |
|Web-based login (QR code) |Authentication aborted when the URL could not be rendered as a QR code, e.g. beyond the maximum QR data capacity |The URL is printed on its own with a warning |Login degrades gracefully instead of failing ([#12721](https://github.com/pnpm/pnpm/issues/12721)). |
|`catalog:` references via a pnpr server |Dependencies and overrides using `catalog:` failed with `No catalog entry '<name>' was found for catalog 'default'.` even when the entry existed |`catalog:` references resolve correctly through a pnpr server |Also fixes a Windows crash when installing a nested workspace member such as `packages/foo` through a pnpr server ([#13232](https://github.com/pnpm/pnpm/issues/13232)). |
|`pnpm run --sequential /regex/` |11.16.0 shipped a script-ordering change for regex-matched sequential runs |That ordering change is reverted |Restores the previous, expected execution order for `pnpm run --sequential` with a regex selector. |
|`pnpm version` |The `from-git` argument was unsupported |`pnpm version from-git` is supported |Brings the command in line with the npm equivalent, reading the version from the current Git tag. |
|`javascript/README.md` |`- pnpm 11.16.0` under `## 1. Environment` |`- pnpm 11.17.0` |Realigns the documented toolchain with the version Corepack actually activates. |
|`typescript/README.md` |`- pnpm 11.16.0` under `## 1. Environment` |`- pnpm 11.17.0` |Same realignment, alongside `WSL (Ubuntu 25.10)` and `Node v26.5.0`. |
|`typescript/package.json` |`"description": "… * Node.js v26.5.0 * pnpm 11.16.0"` |`"description": "… * Node.js v26.5.0 * pnpm 11.17.0"` |Realigns the environment note embedded in `description` for `javascript_primer`. The `packageManager` pin, `dependencies` and `pnpm-lock.yaml` are untouched. |
|`ruby-on-rails/perfect-ruby-on-rails/README.md` |`- pnpm 11.16.0` under `## 1. Environment` |`- pnpm 11.17.0` |Same realignment for the Rails tutorial application. |
|`ruby-on-rails/perfect-ruby-on-rails/package.json` |`"description": "… * Node.js v26.5.0 * pnpm 11.16.0"` |`"description": "… * Node.js v26.5.0 * pnpm 11.17.0"` |Realigns the environment note embedded in `description` for `perfect_ruby_on_rails`. `@hotwired/turbo-rails` and the rest of `dependencies` are untouched. |

## 3. Summary

- Moves the pinned package manager one minor release forward, from pnpm 11.16.0 (2026-07-22) to pnpm 11.17.0 (2026-07-23) — 1 minor change and 6 patch changes, with no intervening release.
- The decisive fix is the republish of every package: v11.13.1 – v11.16.0 tarballs were missing most compiled files, so 11.16.0 was itself a defective publish and this upgrade is corrective rather than optional.
- Adds `update.githubActionsServer` and makes unreadable GitHub Action refs a warning instead of a failure, so `pnpm outdated` / `pnpm update` behave sensibly against private or Enterprise-hosted Actions.
- Hardens web-based registry authentication: the token poll no longer reads non-OK / HTTP 202 bodies and caps the token body at 64 KiB, closing a registry-driven memory-exhaustion vector.
- Repository footprint is 1 commit and 5 files, 5 insertions and 5 deletions — every hunk is the token `11.16.0` → `11.17.0`. No dependency, lockfile or source change, so `JavaScript - CI`, `TypeScript - CI` and the `perfect-ruby-on-rails` CI are unaffected by this branch. `reactjs` needs no edit: its `package.json` carries no environment note in `description` and its README is the unmodified Create React App boilerplate.
- Follow-up required before merge: `javascript/package.json` was missed — its `description` still reads `* pnpm 11.16.0` on this branch while its `packageManager` pin is already `pnpm@11.17.0`. Adding that one-token change leaves no `11.16.0` reference in the repository. The same upgrade is applied in [hayat01sh1da/coding-tests#170](https://github.com/hayat01sh1da/coding-tests/pull/170).

## 4. References

- [pnpm 11.17 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.17.0)
- [pnpm 11.16 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.16.0)
- [pnpm/pnpm#13164 — tarballs missing compiled files](https://github.com/pnpm/pnpm/issues/13164)
- [pnpm/pnpm#13220 — GitHub Actions server and ref handling](https://github.com/pnpm/pnpm/issues/13220)
- [pnpm/pnpm#13232 — `catalog:` resolution through a pnpr server](https://github.com/pnpm/pnpm/issues/13232)
- [pnpm/pnpm#12721 — web-based authentication hardening](https://github.com/pnpm/pnpm/issues/12721)
- [pnpm settings documentation](https://pnpm.io/settings)
- [pnpm on npm](https://www.npmjs.com/package/pnpm)
- [javascript/README.md](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/no-issue/javascript/bump-pnpm-from-11.16.0-to-11.17.0/javascript/README.md)
- [typescript/README.md](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/no-issue/javascript/bump-pnpm-from-11.16.0-to-11.17.0/typescript/README.md)
- [typescript/package.json](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/no-issue/javascript/bump-pnpm-from-11.16.0-to-11.17.0/typescript/package.json)
- [ruby-on-rails/perfect-ruby-on-rails/README.md](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/no-issue/javascript/bump-pnpm-from-11.16.0-to-11.17.0/ruby-on-rails/perfect-ruby-on-rails/README.md)
- [ruby-on-rails/perfect-ruby-on-rails/package.json](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/no-issue/javascript/bump-pnpm-from-11.16.0-to-11.17.0/ruby-on-rails/perfect-ruby-on-rails/package.json)
- [javascript/package.json (pending follow-up)](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/no-issue/javascript/bump-pnpm-from-11.16.0-to-11.17.0/javascript/package.json)
- [.github/workflows/javascript--daily-dependencies-update.yml](https://github.com/hayat01sh1da/tutorials/blob/master/.github/workflows/javascript--daily-dependencies-update.yml)
- [Corepack documentation](https://nodejs.org/api/corepack.html)
