### PR TITLE
[github-actions] Install libvips for ruby-vips in Ruby on Rails CI

### DIFF
--- a/.github/actions/setup-ruby-on-rails/action.yml
+++ b/.github/actions/setup-ruby-on-rails/action.yml
@@ -23,6 +23,15 @@ runs:
       run: |
         bundle config set --local path 'vendor/bundle'
         bundle install
+    # ruby-vips binds libvips.so.42 through FFI, so booting the application
+    # raises LoadError unless the native library is present on the runner.
+    # endsWith because callers pass the path both with and without a leading './'.
+    - name: Install libvips
+      if: ${{ endsWith(inputs.working-directory, 'ruby-on-rails/perfect-ruby-on-rails') }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y libvips
     - name: Set up Database
       if: ${{ inputs.job-name == 'minitest' || inputs.job-name == 'RSpec' }}
       shell: bash


### PR DESCRIPTION
## 1. Overview

The `minitest` job of the `Ruby on Rails - Perfect Ruby on Rails - CI` workflow has been failing since `ruby-vips` was added to the Gemfile in 97386cd.  
`ruby-vips` is a pure-Ruby FFI binding, so installing the gem does not install the native `libvips` library it dlopens at load time, and `ubuntu-24.04` runners do not ship it.  

As a result `Bundler.require` aborts while `bin/setup` boots the application, and the whole job dies before a single test runs:  

~~~console
Bundler::GemRequireError: There was an error while trying to load the gem 'ruby-vips'.
Gem Load Error is: Could not open library 'vips.so.42': vips.so.42: cannot open shared object file: No such file or directory.
Could not open library 'libvips.so.42': libvips.so.42: cannot open shared object file: No such file or directory.
~~~

This pull request installs the native library on the runner so the application can boot again.  

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`.github/actions/setup-ruby-on-rails/action.yml` |No native image library is installed; `ruby-vips` fails to dlopen `libvips.so.42` and `bin/setup` aborts with `Bundler::GemRequireError` |A new `Install libvips` step runs `sudo apt-get install --no-install-recommends -y libvips` before the database is set up |The application boots again in CI, so `bin/setup` and `bin/rails test` reach the test suite |

## 3. Summary

The step is scoped with `endsWith(inputs.working-directory, 'ruby-on-rails/perfect-ruby-on-rails')` because it is the only application depending on `image_processing`/`ruby-vips`; `e-navigator` and `restful-api` keep their current setup time untouched.  
`endsWith` rather than `==` is deliberate: the CI workflows pass `./ruby-on-rails/perfect-ruby-on-rails` while `Ruby on Rails - Daily Dependencies Update` passes `ruby-on-rails/perfect-ruby-on-rails`, and the condition has to hold for both.  

`libvips` is a virtual package provided by `libvips42t64` on `ubuntu-24.04`, so the unversioned name keeps working across runner image upgrades instead of pinning a release-specific `libvipsNN` package.  

The gem itself is genuinely required — `Event#image` is an Active Storage attachment rendered through `image.variant(resize_to_fit: [200, 200])` in `app/helpers/event_helper.rb`, and Rails resolves variants with the `:vips` processor by default — so removing `ruby-vips` was not an option.  

Only the `minitest` job was affected; `brakeman`, `rubocop` and `steep` passed because none of them boot the application.  

Note for a follow-up (deliberately left out of this pull request): the neighbouring `Install Google Chrome` step is gated on `inputs.working-directory == 'ruby-on-rails/perfect-ruby-on-rails'`, which never matches the `./`-prefixed value the CI workflows pass — the step has been silently skipped in every CI run.  

## 4. References

- [Failing workflow run](https://github.com/hayat01sh1da/tutorials/actions/runs/30575681850/job/91063677961)
- [.github/actions/setup-ruby-on-rails/action.yml](https://github.com/hayat01sh1da/tutorials/blob/hayat01sh1da/github-actions/install-libvips-for-ruby-vips-in-ruby-on-rails-ci/.github/actions/setup-ruby-on-rails/action.yml)
- [ruby-vips installation requirements](https://github.com/libvips/ruby-vips#installation)
- [libvips42t64 on Ubuntu 24.04 (noble)](https://packages.ubuntu.com/noble/libvips42t64)
- [Active Storage variant processors](https://guides.rubyonrails.org/active_storage_overview.html#transforming-images)
